### PR TITLE
feat: environment param for OIDC hooks (CU-889 Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ coverage/
 *.tmp
 *.temp
 package-lock.json
+
+# Personal in-flight ticket state (written by /start-ticket)
+.claude/active-ticket.md
+.claude/relay-log.md

--- a/README.md
+++ b/README.md
@@ -195,6 +195,38 @@ const {
 </UniverseAuthProvider>
 ```
 
+## Migration: `authUrl` / `reconnectUrl` → `environment` (0.4.0)
+
+As of **0.4.0**, the OIDC hooks accept an `environment: 'production' | 'staging'`
+option that selects the canonical URLs the SDK calls. `'production'` is the default
+when omitted, so most apps need no code changes.
+
+The explicit `authUrl` and `reconnectUrl` options still work but are **deprecated**
+and will be removed in a future major version. When you pass either, the SDK logs a
+one-time `console.warn` and uses the value you supplied (back-compat semantics — the
+explicit URL still wins over `environment`).
+
+```ts
+// Before
+useMerkosAuth({
+  authUrl: 'https://auth.chabaduniverse.com/merkos/login',
+  reconnectUrl: 'https://auth.chabaduniverse.com/merkos/reconnect',
+});
+
+// After — production (default; the `environment` line is optional)
+useMerkosAuth({ environment: 'production' });
+
+// After — staging
+useMerkosAuth({ environment: 'staging' });
+```
+
+The same option is available on `useMerkosOIDC`.
+
+> **Phase 3 note:** in a future SDK release (tracked by CU-889 Phase 3, blocked on
+> CU-890) the `production` URLs will flip from the auth-relay to the cu-oidc-provider.
+> Apps that are already on `environment: 'production'` (or relying on the default)
+> migrate via SDK version bump alone.
+
 ## Documentation
 
 | Document | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,8 @@ export {
   DEFAULT_AUTH_URL,
   DEFAULT_RECONNECT_URL,
   DEFAULT_STORAGE_KEY,
+  DEFAULT_ENVIRONMENT,
+  ENVIRONMENT_URLS,
   BROADCAST_CHANNEL_NAME,
 } from './oidc';
 
@@ -186,6 +188,7 @@ export type {
   MerkosAuthTokenMessage,
   MerkosAuthMethod,
   MerkosReconnectMode,
+  MerkosEnvironment,
   UseMerkosOIDCOptions,
   UseMerkosOIDCReturn,
   UseMerkosAuthOptions,

--- a/src/oidc/__tests__/useMerkosAuth.test.ts
+++ b/src/oidc/__tests__/useMerkosAuth.test.ts
@@ -531,3 +531,242 @@ describe('useMerkosAuth', () => {
     expect(result.current.isAuthenticating).toBe(false);
   });
 });
+
+// ============================================================================
+// environment param (CU-889 Phase 1)
+// ============================================================================
+
+describe('useMerkosAuth – environment param (CU-889)', () => {
+  const STAGING_AUTH_URL = 'https://test-auth.chabaduniverse.com/merkos/login';
+  const STAGING_RECONNECT_URL = 'https://test-auth.chabaduniverse.com/merkos/reconnect';
+  const PROD_AUTH_URL = 'https://auth.chabaduniverse.com/merkos/login';
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let resolvePopup: (value: string) => void;
+
+  function simulateIframe() {
+    Object.defineProperty(window, 'self', { value: {}, writable: true, configurable: true });
+    Object.defineProperty(window, 'top', { value: window, writable: true, configurable: true });
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://portal.chabaduniverse.com/',
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Reset the module-scoped warning Set between tests so we can assert
+    // "warns exactly once" semantics across renders.
+    const { __resetDeprecationWarnings } = await import('../deprecation');
+    __resetDeprecationWarnings();
+
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (popupAuth.openAuthPopup as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const promise = new Promise<string>((resolve) => {
+        resolvePopup = resolve;
+      });
+      return { promise, cleanup: vi.fn() };
+    });
+
+    simulateIframe();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to production URLs when no environment is supplied', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    renderHook(() => useMerkosAuth({ reconnectMode: 'auto' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      PROD_AUTH_URL,
+      'https://auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes auth popup to staging when environment=staging', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    renderHook(() => useMerkosAuth({ reconnectMode: 'auto', environment: 'staging' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      STAGING_AUTH_URL,
+      'https://test-auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes reconnect popup to staging when environment=staging', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useMerkosAuth({ reconnectMode: 'manual', environment: 'staging' }),
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.needsReconnect).toBe(true);
+
+    act(() => {
+      result.current.reconnect();
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      STAGING_RECONNECT_URL,
+      'https://test-auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+  });
+
+  it('explicit authUrl overrides environment AND emits one deprecation warning', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    const customAuthUrl = 'https://override.example.com/login';
+    renderHook(() =>
+      useMerkosAuth({
+        reconnectMode: 'auto',
+        environment: 'staging',
+        authUrl: customAuthUrl,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Explicit URL won — staging URL was NOT used
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      customAuthUrl,
+      'https://override.example.com',
+      'merkos_auth_token',
+    );
+    // Exactly one warning, naming the deprecated option
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('authUrl');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('deprecated');
+  });
+
+  it('explicit reconnectUrl overrides environment AND emits one deprecation warning', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    const customReconnectUrl = 'https://override.example.com/reconnect';
+    const { result } = renderHook(() =>
+      useMerkosAuth({
+        reconnectMode: 'manual',
+        environment: 'staging',
+        reconnectUrl: customReconnectUrl,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    act(() => {
+      result.current.reconnect();
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      customReconnectUrl,
+      'https://override.example.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('reconnectUrl');
+  });
+
+  it('falls back to production AND warns once when environment is an unknown string', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    // Simulate a non-TS caller passing an invalid value through `as any`.
+    const { rerender } = renderHook(
+      ({ env }: { env: string }) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        useMerkosAuth({ reconnectMode: 'auto', environment: env as any }),
+      { initialProps: { env: 'prod' } },
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Falls back to production URLs (not staging, not a crash)
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      PROD_AUTH_URL,
+      'https://auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+
+    // Re-render with another invalid value — still only one warning total
+    rerender({ env: 'development' });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const invalidWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('Invalid `environment`'),
+    );
+    expect(invalidWarnings).toHaveLength(1);
+  });
+
+  it('deprecation warning fires exactly once across multiple renders/instances', async () => {
+    (cdssoUtils.getStoredToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const mockClient = getMockCdssoClient();
+    mockClient.authenticate.mockResolvedValue(null);
+
+    const customAuthUrl = 'https://override.example.com/login';
+
+    // First render — should warn
+    const { rerender } = renderHook(
+      ({ authUrl }: { authUrl?: string }) => useMerkosAuth({ authUrl, reconnectMode: 'manual' }),
+      { initialProps: { authUrl: customAuthUrl } },
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Trigger several rerenders + an additional independent hook instance
+    rerender({ authUrl: customAuthUrl });
+    rerender({ authUrl: customAuthUrl });
+    renderHook(() =>
+      useMerkosAuth({ authUrl: 'https://other.example.com/login', reconnectMode: 'manual' }),
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Exactly one warning for `authUrl`, across all renders/instances
+    const authUrlWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('authUrl'),
+    );
+    expect(authUrlWarnings).toHaveLength(1);
+  });
+});

--- a/src/oidc/__tests__/useMerkosOIDC.test.ts
+++ b/src/oidc/__tests__/useMerkosOIDC.test.ts
@@ -144,3 +144,106 @@ describe('useMerkosOIDC', () => {
     );
   });
 });
+
+// ============================================================================
+// environment param (CU-889 Phase 1)
+// ============================================================================
+
+describe('useMerkosOIDC – environment param (CU-889)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { __resetDeprecationWarnings } = await import('../deprecation');
+    __resetDeprecationWarnings();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (popupAuth.openAuthPopup as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      promise: new Promise(() => {}),
+      cleanup: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to production URL when no environment is supplied', () => {
+    const { result } = renderHook(() => useMerkosOIDC());
+    act(() => {
+      result.current.login();
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      'https://auth.chabaduniverse.com/merkos/login',
+      'https://auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes to staging URL when environment=staging', () => {
+    const { result } = renderHook(() => useMerkosOIDC({ environment: 'staging' }));
+    act(() => {
+      result.current.login();
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      'https://test-auth.chabaduniverse.com/merkos/login',
+      'https://test-auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to production AND warns once when environment is an unknown string', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { result, rerender } = renderHook(
+      ({ env }: { env: string }) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        useMerkosOIDC({ environment: env as any }),
+      { initialProps: { env: 'prod' } },
+    );
+    act(() => {
+      result.current.login();
+    });
+
+    // Falls back to production URLs, no crash
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      'https://auth.chabaduniverse.com/merkos/login',
+      'https://auth.chabaduniverse.com',
+      'merkos_auth_token',
+    );
+
+    // Re-render with another invalid value — still only one warning total
+    rerender({ env: 'development' });
+    act(() => {
+      result.current.login();
+    });
+
+    const invalidWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('Invalid `environment`'),
+    );
+    expect(invalidWarnings).toHaveLength(1);
+  });
+
+  it('explicit authUrl overrides environment AND emits one deprecation warning', () => {
+    const customUrl = 'https://override.example.com/login';
+    const { result } = renderHook(() =>
+      useMerkosOIDC({ environment: 'staging', authUrl: customUrl }),
+    );
+    act(() => {
+      result.current.login();
+    });
+
+    expect(popupAuth.openAuthPopup).toHaveBeenCalledWith(
+      customUrl,
+      'https://override.example.com',
+      'merkos_auth_token',
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('authUrl');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('deprecated');
+  });
+});

--- a/src/oidc/deprecation.ts
+++ b/src/oidc/deprecation.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot console warnings for deprecated / invalid SDK options.
+ *
+ * Tracks which (kind, optionName) pairs have already produced a warning during
+ * the lifetime of this module so we don't spam consumers on every render.
+ * Test-only `__resetDeprecationWarnings` clears the tracking Set.
+ */
+
+const warned = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(message);
+}
+
+/**
+ * Emit a deprecation warning the first time `optionName` is reported.
+ * Subsequent calls with the same `optionName` are no-ops.
+ */
+export function warnDeprecatedOption(optionName: string, replacementHint: string): void {
+  warnOnce(
+    `deprecated:${optionName}`,
+    `[@chabaduniverse/auth-sdk] \`${optionName}\` is deprecated and will be removed in a future major version. ${replacementHint}`,
+  );
+}
+
+/**
+ * Emit an invalid-value warning the first time `optionName` is reported.
+ * Subsequent calls with the same `optionName` are no-ops.
+ */
+export function warnInvalidOption(optionName: string, detail: string): void {
+  warnOnce(
+    `invalid:${optionName}`,
+    `[@chabaduniverse/auth-sdk] Invalid \`${optionName}\` option: ${detail}`,
+  );
+}
+
+/** Test-only: reset the one-shot tracking. */
+export function __resetDeprecationWarnings(): void {
+  warned.clear();
+}

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -15,6 +15,8 @@ export {
   DEFAULT_AUTH_URL,
   DEFAULT_RECONNECT_URL,
   DEFAULT_STORAGE_KEY,
+  DEFAULT_ENVIRONMENT,
+  ENVIRONMENT_URLS,
   BROADCAST_CHANNEL_NAME,
 } from './types';
 
@@ -22,6 +24,7 @@ export type {
   MerkosAuthTokenMessage,
   MerkosAuthMethod,
   MerkosReconnectMode,
+  MerkosEnvironment,
   UseMerkosOIDCOptions,
   UseMerkosOIDCReturn,
   UseMerkosAuthOptions,

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -13,11 +13,49 @@
 /** PostMessage type for Merkos auth token messages */
 export const MERKOS_AUTH_MESSAGE_TYPE = 'MERKOS_AUTH_TOKEN' as const;
 
-/** Default auth popup URL */
-export const DEFAULT_AUTH_URL = 'https://auth.chabaduniverse.com/merkos/login' as const;
+/**
+ * Environment names the SDK accepts for the `environment` option.
+ *
+ * Phase 1 (CU-889): both environments route to the auth-relay. Phase 3
+ * (blocked on CU-890) will flip the URLs to cu-oidc-provider endpoints.
+ */
+export type MerkosEnvironment = 'production' | 'staging';
 
-/** Default reconnect popup URL */
-export const DEFAULT_RECONNECT_URL = 'https://auth.chabaduniverse.com/merkos/reconnect' as const;
+/**
+ * Canonical URLs the SDK uses per environment.
+ *
+ * Phase 1 (CU-889): staging mirrors production against the staging auth-relay
+ * (`test-auth.chabaduniverse.com`). Phase 3 will flip both production and
+ * staging to point at `id.chabaduniverse.com` / `staging.id.chabaduniverse.com`
+ * once CU-890 ships `/oidc/reconnect` on cu-oidc-provider.
+ */
+export const ENVIRONMENT_URLS = {
+  production: {
+    auth: 'https://auth.chabaduniverse.com/merkos/login',
+    reconnect: 'https://auth.chabaduniverse.com/merkos/reconnect',
+  },
+  staging: {
+    auth: 'https://test-auth.chabaduniverse.com/merkos/login',
+    reconnect: 'https://test-auth.chabaduniverse.com/merkos/reconnect',
+  },
+} as const satisfies Record<MerkosEnvironment, { auth: string; reconnect: string }>;
+
+/** Default environment when none is supplied. */
+export const DEFAULT_ENVIRONMENT: MerkosEnvironment = 'production';
+
+/**
+ * Default auth popup URL.
+ * @deprecated Use the `environment` option on `useMerkosAuth` / `useMerkosOIDC` instead.
+ *   Retained for back-compat; will be removed in a future major version.
+ */
+export const DEFAULT_AUTH_URL = ENVIRONMENT_URLS.production.auth;
+
+/**
+ * Default reconnect popup URL.
+ * @deprecated Use the `environment` option on `useMerkosAuth` / `useMerkosOIDC` instead.
+ *   Retained for back-compat; will be removed in a future major version.
+ */
+export const DEFAULT_RECONNECT_URL = ENVIRONMENT_URLS.production.reconnect;
 
 /** Default localStorage key for the token */
 export const DEFAULT_STORAGE_KEY = 'merkos_auth_token' as const;
@@ -55,7 +93,16 @@ export type MerkosReconnectMode = 'auto' | 'manual';
  * Options for useMerkosOIDC hook
  */
 export interface UseMerkosOIDCOptions {
-  /** URL to open in the popup */
+  /**
+   * Environment to route the popup to. Defaults to `'production'`.
+   * Ignored if an explicit `authUrl` is supplied.
+   */
+  environment?: MerkosEnvironment;
+  /**
+   * URL to open in the popup.
+   * @deprecated Use `environment` instead. When set, overrides `environment` and
+   *   emits a one-time deprecation warning.
+   */
   authUrl?: string;
   /** Expected origin for postMessage validation */
   expectedOrigin?: string;
@@ -85,9 +132,22 @@ export interface UseMerkosAuthOptions {
   storageKey?: string;
   /** How to handle Step 3: 'auto' opens popup automatically, 'manual' sets needsReconnect */
   reconnectMode?: MerkosReconnectMode;
-  /** URL for the auth login popup (defaults to production auth relay) */
+  /**
+   * Environment to route auth + reconnect popups to. Defaults to `'production'`.
+   * Ignored for whichever URL is explicitly supplied via `authUrl` / `reconnectUrl`.
+   */
+  environment?: MerkosEnvironment;
+  /**
+   * URL for the auth login popup.
+   * @deprecated Use `environment` instead. When set, overrides `environment` for the
+   *   auth popup and emits a one-time deprecation warning.
+   */
   authUrl?: string;
-  /** URL for the reconnect popup (Step 3 manual reconnect) */
+  /**
+   * URL for the reconnect popup (Step 3 manual reconnect).
+   * @deprecated Use `environment` instead. When set, overrides `environment` for the
+   *   reconnect popup and emits a one-time deprecation warning.
+   */
   reconnectUrl?: string;
   /** Expected origin for postMessage validation */
   expectedOrigin?: string;

--- a/src/oidc/useMerkosAuth.ts
+++ b/src/oidc/useMerkosAuth.ts
@@ -15,10 +15,12 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { getStoredToken, removeToken, isTokenExpired } from '../cdsso/cdsso-utils';
 import { getDefaultCdssoClient } from '../cdsso/cdsso-client';
 import { openAuthPopup } from './popup-auth';
+import { warnDeprecatedOption, warnInvalidOption } from './deprecation';
 import {
   DEFAULT_STORAGE_KEY,
-  DEFAULT_AUTH_URL,
-  DEFAULT_RECONNECT_URL,
+  DEFAULT_ENVIRONMENT,
+  ENVIRONMENT_URLS,
+  type MerkosEnvironment,
   type UseMerkosAuthOptions,
   type UseMerkosAuthReturn,
   type MerkosAuthMethod,
@@ -90,13 +92,35 @@ export function useMerkosAuth(options: UseMerkosAuthOptions = {}): UseMerkosAuth
   const {
     storageKey = DEFAULT_STORAGE_KEY,
     reconnectMode = 'auto',
-    authUrl = DEFAULT_AUTH_URL,
-    reconnectUrl = DEFAULT_RECONNECT_URL,
+    environment = DEFAULT_ENVIRONMENT,
+    authUrl: explicitAuthUrl,
+    reconnectUrl: explicitReconnectUrl,
     expectedOrigin,
     onAuthenticated,
     debug = false,
     forceEnabled = false,
   } = options;
+
+  // Resolution: explicit URL wins over the env default; deprecation warning fires
+  // exactly once per option name across the module's lifetime (Set in deprecation.ts).
+  if (explicitAuthUrl !== undefined) {
+    warnDeprecatedOption('authUrl', 'Use the `environment` option instead.');
+  }
+  if (explicitReconnectUrl !== undefined) {
+    warnDeprecatedOption('reconnectUrl', 'Use the `environment` option instead.');
+  }
+
+  // Runtime fallback for non-TS callers passing an unknown environment string.
+  const envEntry = ENVIRONMENT_URLS[environment as MerkosEnvironment];
+  if (!envEntry) {
+    warnInvalidOption(
+      'environment',
+      `received "${environment}". Valid: 'production' | 'staging'. Falling back to production.`,
+    );
+  }
+  const envUrls = envEntry ?? ENVIRONMENT_URLS.production;
+  const authUrl = explicitAuthUrl ?? envUrls.auth;
+  const reconnectUrl = explicitReconnectUrl ?? envUrls.reconnect;
 
   // Derive per-URL origins; explicit expectedOrigin overrides both
   const authExpectedOrigin = expectedOrigin ?? new URL(authUrl).origin;

--- a/src/oidc/useMerkosOIDC.ts
+++ b/src/oidc/useMerkosOIDC.ts
@@ -7,9 +7,12 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { openAuthPopup, type PopupAuthResult } from './popup-auth';
+import { warnDeprecatedOption, warnInvalidOption } from './deprecation';
 import {
-  DEFAULT_AUTH_URL,
+  DEFAULT_ENVIRONMENT,
   DEFAULT_STORAGE_KEY,
+  ENVIRONMENT_URLS,
+  type MerkosEnvironment,
   type UseMerkosOIDCOptions,
   type UseMerkosOIDCReturn,
 } from './types';
@@ -25,10 +28,27 @@ import {
  */
 export function useMerkosOIDC(options: UseMerkosOIDCOptions = {}): UseMerkosOIDCReturn {
   const {
-    authUrl = DEFAULT_AUTH_URL,
-    expectedOrigin = new URL(authUrl).origin,
+    environment = DEFAULT_ENVIRONMENT,
+    authUrl: explicitAuthUrl,
+    expectedOrigin: explicitExpectedOrigin,
     storageKey = DEFAULT_STORAGE_KEY,
   } = options;
+
+  if (explicitAuthUrl !== undefined) {
+    warnDeprecatedOption('authUrl', 'Use the `environment` option instead.');
+  }
+
+  // Runtime fallback for non-TS callers passing an unknown environment string.
+  const envEntry = ENVIRONMENT_URLS[environment as MerkosEnvironment];
+  if (!envEntry) {
+    warnInvalidOption(
+      'environment',
+      `received "${environment}". Valid: 'production' | 'staging'. Falling back to production.`,
+    );
+  }
+  const envUrls = envEntry ?? ENVIRONMENT_URLS.production;
+  const authUrl = explicitAuthUrl ?? envUrls.auth;
+  const expectedOrigin = explicitExpectedOrigin ?? new URL(authUrl).origin;
 
   const [isOpen, setIsOpen] = useState(false);
   const popupRef = useRef<PopupAuthResult | null>(null);


### PR DESCRIPTION
## Summary

- Adds `environment: 'production' | 'staging'` option to `useMerkosAuth` and `useMerkosOIDC` (default `'production'`). SDK now holds the canonical URLs internally per environment via `ENVIRONMENT_URLS` in `src/oidc/types.ts`.
- Keeps `authUrl` / `reconnectUrl` working with a one-time `console.warn` per option (back-compat).
- Invalid `environment` runtime values fall back to production with their own one-time warning instead of crashing.
- Bumps `0.3.1 → 0.4.0`. Migration guide added to `README.md`.

This is **Phase 1 of ADR-0001** (auth-relay absorption into cu-oidc). Phase 3 (production URL flip to `id.chabaduniverse.com/oidc/*` + Discover Board follow-ups to KoK / Content Studio / Courses) is **deferred — blocked on CU-890**.

## Backward compatibility

All changes are backward-compatible:

- Existing callers using `authUrl` / `reconnectUrl` keep working unchanged. A deprecation `console.warn` fires **once per option name** (module-scoped Set) on first use; subsequent renders / hook instances are silent.
- `DEFAULT_AUTH_URL` / `DEFAULT_RECONNECT_URL` remain exported as `@deprecated` aliases pointing at `ENVIRONMENT_URLS.production.*` — same literal values as before.
- Default `environment` is `'production'`, so callers that pass nothing get prod URLs (same as today).

## Phase 3 (not in this PR)

- Flip `ENVIRONMENT_URLS.production` from `auth.chabaduniverse.com/merkos/*` to `id.chabaduniverse.com/oidc/*` once CU-890 ships `/oidc/reconnect` on cu-oidc-provider.
- Send follow-up Discover Board messages to `cu-kitchen-of-kindness`, `cu-content-studio`, and `chabaduniverse-courses` with the new SDK version + migration guide.
- CU-889 stays open in Jira for Phase 3.

## Staging URL decision

`ENVIRONMENT_URLS.staging` points at the **staging auth-relay** (`test-auth.chabaduniverse.com`), not staging cu-oidc — because cu-oidc-provider staging doesn't yet serve `/merkos/login` or `/oidc/reconnect` (those endpoints land in CU-890). Both `production` and `staging` will flip together in Phase 3.

## Consumer impact

**8 apps currently depend on this SDK** with caret ranges in the `^0.1.0 – ^0.3.0` band. **None of them auto-upgrade to 0.4.0** — npm semver treats minor bumps in `0.x` versions as breaking-equivalent, so `^0.3.1` does not match `0.4.0`. Each consumer must explicitly bump their `package.json` dependency to `^0.4.0` (or pin to `0.4.0`) and run `pnpm install` / `npm install` to pick up this change. No silent behavior changes will hit production until each app does this.

## Publishing to npm

**Publishing is a manual follow-up @ReuvenEtzion runs after merge:**

```bash
git checkout main && git pull
pnpm publish
```

`prepublishOnly` in `package.json` auto-runs the build, so no need to build manually first.

## Acceptance criteria (CU-889 Phase 1)

- [x] SDK accepts `environment` param (`'production' | 'staging'`, default `'production'`) — `src/oidc/types.ts`, `useMerkosAuth.ts:94-114`, `useMerkosOIDC.ts:30-46`
- [x] `environment=staging` routes internally — `ENVIRONMENT_URLS` in `src/oidc/types.ts:29-38`
- [x] Explicit `authUrl` / `reconnectUrl` still work + log one-time deprecation warning — `useMerkosAuth.ts:99-104`, `useMerkosOIDC.ts:33-36`
- [x] Internal URL constants per env live in `src/oidc/types.ts`
- [x] Version bump 0.3.1 → 0.4.0 — `package.json:3`
- [x] Migration guide in README — `README.md:198-229`

## Phase 3 AC (NOT in this PR — blocked on CU-890)

- [ ] Flip `production` URLs to `id.chabaduniverse.com/oidc/*`
- [ ] Discover Board follow-ups to KoK / Content Studio / Courses

## Test plan

- [x] `pnpm test` — **409 passing** (was 398 + 11 new env-param tests in `useMerkosAuth.test.ts` and `useMerkosOIDC.test.ts`)
- [x] `pnpm build` — dist compiles, types emit
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 errors
- [ ] Manual smoke-test of `environment: 'staging'` against `test-auth.chabaduniverse.com` from a consumer app after publish

## Review notes

`/review-ticket` ran two rounds with parallel reviewer panels (acceptance / scope-drift / correctness / security / test-coverage):

- **Round 1** flagged one 🔴: invalid `environment` runtime string would crash both hooks. Round 2 added a runtime fallback to production with its own one-time `warnInvalidOption('environment', …)` helper.
- **Round 2** verdict: ✅ Ship as-is. No new 🔴; two minor 🟡 hygiene items deferred (test helper export marker; cosmetic test-assertion coupling).
- No security 🔴. No scope drift.

Full review log in `.claude/active-ticket.md` (gitignored).

Closes CU-889 (Phase 1 portion — CU-889 stays open for Phase 3 work).