### PR TITLE
🔧 chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ package-lock.json
 # Personal in-flight ticket state (written by /start-ticket)
 .claude/active-ticket.md
 .claude/relay-log.md
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` so the `/start-ticket` skill's dispatched-agent worktrees don't show up as untracked

## Why
The `/start-ticket` agent creates a worktree at `.claude/worktrees/<short-id>/` when it needs to isolate its work from the main checkout. Without a `.gitignore` entry, the directory blocks `pnpm publish` (which fails on `ERR_PNPM_GIT_UNCLEAN` for any untracked file).

Surfaced during CU-889 Phase 1 publish — first time the worktree pattern landed in this repo. Follow-up to PR #29.

## Test plan
- [ ] Verify `git status` ignores `.claude/worktrees/` after merge
- [ ] Next `/start-ticket` dispatch creates a worktree and `pnpm publish` doesn't trip on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)