### PR TITLE
feat(cu-oidc): add cu-oidc-native mode to auth-sdk (CU-1029)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "0.4.0",
+  "version": "1.0.0-beta.1",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -85,6 +85,16 @@
       "require": {
         "types": "./dist/oidc/index.d.cts",
         "default": "./dist/oidc/index.cjs"
+      }
+    },
+    "./cu-oidc": {
+      "import": {
+        "types": "./dist/cu-oidc/index.d.ts",
+        "default": "./dist/cu-oidc/index.js"
+      },
+      "require": {
+        "types": "./dist/cu-oidc/index.d.cts",
+        "default": "./dist/cu-oidc/index.cjs"
       }
     }
   },

--- a/src/cu-oidc/__tests__/claims.test.ts
+++ b/src/cu-oidc/__tests__/claims.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for claim accessors + token-lifecycle helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getClaims,
+  getNamespace,
+  getShliachStatus,
+  getTokenExpiration,
+  isTokenExpired,
+} from '../claims';
+import { bytesToBase64Url } from '../crypto-utils';
+import type { CuOidcClaims } from '../types';
+
+/** Build an UNSIGNED JWT string carrying `payload` (decode-only tests). */
+function makeJwt(payload: Record<string, unknown>): string {
+  const h = bytesToBase64Url(new TextEncoder().encode(JSON.stringify({ alg: 'RS256', typ: 'JWT' })));
+  const p = bytesToBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  return `${h}.${p}.sig`;
+}
+
+const claims: CuOidcClaims = {
+  sub: 'cu-1',
+  chabaduniverse: { user_id: 'cu-1', is_shliach: true, chabad_org_id: '770' },
+  valu: { user_id: 'valu-1' },
+  merkos: { sub: 'neo4j-1', shliachAccess: true },
+};
+
+describe('getClaims', () => {
+  it('decodes the three namespaces from a token', () => {
+    const decoded = getClaims(makeJwt(claims));
+    expect(decoded?.sub).toBe('cu-1');
+    expect(decoded?.chabaduniverse?.chabad_org_id).toBe('770');
+    expect(decoded?.valu?.user_id).toBe('valu-1');
+    expect(decoded?.merkos?.sub).toBe('neo4j-1');
+  });
+});
+
+describe('getNamespace', () => {
+  it('returns the requested namespace from a token or claim object', () => {
+    expect(getNamespace(claims, 'chabaduniverse')?.is_shliach).toBe(true);
+    expect(getNamespace(makeJwt(claims), 'valu')?.user_id).toBe('valu-1');
+    expect(getNamespace(claims, 'merkos')?.shliachAccess).toBe(true);
+  });
+
+  it('returns null for an absent namespace', () => {
+    expect(getNamespace({ sub: 'x' }, 'chabaduniverse')).toBeNull();
+    expect(getNamespace(null, 'valu')).toBeNull();
+  });
+});
+
+describe('getShliachStatus', () => {
+  it('prefers chabaduniverse.is_shliach', () => {
+    expect(getShliachStatus(claims)).toBe(true);
+    expect(getShliachStatus({ sub: 'x', chabaduniverse: { is_shliach: false } })).toBe(false);
+  });
+
+  it('falls back to merkos.shliachAccess when is_shliach is absent', () => {
+    expect(getShliachStatus({ sub: 'x', merkos: { shliachAccess: true } })).toBe(true);
+  });
+
+  it('returns false when neither signal is present', () => {
+    expect(getShliachStatus({ sub: 'x' })).toBe(false);
+    expect(getShliachStatus(null)).toBe(false);
+  });
+});
+
+describe('token lifecycle', () => {
+  it('getTokenExpiration returns exp in ms', () => {
+    const token = makeJwt({ sub: 'x', exp: 1000 });
+    expect(getTokenExpiration(token)).toBe(1_000_000);
+  });
+
+  it('getTokenExpiration returns null when exp is missing', () => {
+    expect(getTokenExpiration(makeJwt({ sub: 'x' }))).toBeNull();
+  });
+
+  it('isTokenExpired is true for a past exp and false for a future one', () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(isTokenExpired(makeJwt({ sub: 'x', exp: nowSec - 3600 }))).toBe(true);
+    expect(isTokenExpired(makeJwt({ sub: 'x', exp: nowSec + 3600 }))).toBe(false);
+  });
+
+  it('isTokenExpired honors the buffer (proactive refresh window)', () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    // exp is 30s away; a 60s buffer treats it as already expired.
+    expect(isTokenExpired(makeJwt({ sub: 'x', exp: nowSec + 30 }), 60)).toBe(true);
+    expect(isTokenExpired(makeJwt({ sub: 'x', exp: nowSec + 30 }), 5)).toBe(false);
+  });
+
+  it('isTokenExpired is true for a malformed token', () => {
+    expect(isTokenExpired('garbage')).toBe(true);
+  });
+});

--- a/src/cu-oidc/__tests__/client.test.ts
+++ b/src/cu-oidc/__tests__/client.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the composed cu-oidc client factory.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCuOidcClient } from '../client';
+import { clearJwksCache } from '../jwks';
+import { generateTestKey, sampleClaims, signTestJwt, type TestKey } from './test-helpers';
+
+function makeClient() {
+  return createCuOidcClient({
+    clientId: 'cu-harness-consumer-b',
+    redirectUri: 'https://app.example.com/auth/callback',
+    environment: 'staging',
+  });
+}
+
+let key: TestKey;
+
+beforeEach(async () => {
+  clearJwksCache();
+  localStorage.clear();
+  sessionStorage.clear();
+  key = await generateTestKey();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('createCuOidcClient — config', () => {
+  it('exposes the resolved config + endpoints', () => {
+    const c = makeClient();
+    expect(c.config.issuer).toBe('https://staging.oidc.merkos302.com');
+    expect(c.config.endpoints.token).toBe('https://staging.oidc.merkos302.com/oidc/token');
+  });
+});
+
+describe('token-lifecycle accessors', () => {
+  it('reflects a stored token via getStoredToken / getCurrentUser / isAuthenticated', async () => {
+    const c = makeClient();
+    expect(c.getStoredToken()).toBeNull();
+    expect(c.isAuthenticated()).toBe(false);
+
+    const token = await signTestJwt(key, sampleClaims());
+    localStorage.setItem('cu_id_token', token);
+
+    expect(c.getStoredToken()).toBe(token);
+    expect(c.getCurrentUser()?.sub).toBe('cu-user-123');
+    expect(c.isAuthenticated()).toBe(true);
+    expect(c.isTokenExpired()).toBe(false);
+    expect(typeof c.getTokenExpiration()).toBe('number');
+    expect(c.getShliachStatus(c.getCurrentUser())).toBe(true);
+    expect(c.getNamespace(token, 'merkos')?.sub).toBe('neo4j-uuid-xyz');
+  });
+
+  it('treats an expired stored token as unauthenticated', async () => {
+    const c = makeClient();
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signTestJwt(key, sampleClaims({ exp: past }));
+    localStorage.setItem('cu_id_token', token);
+    // A stored-but-expired token ⇒ not authenticated.
+    expect(c.getStoredToken()).toBe(token);
+    expect(c.isAuthenticated()).toBe(false);
+  });
+});
+
+describe('verify', () => {
+  it('delegates to verifyIdToken with the client issuer + jwks endpoint', async () => {
+    const c = makeClient();
+    const token = await signTestJwt(key, sampleClaims());
+    const claims = await c.verify(token, { jwks: key.jwks });
+    expect(claims.sub).toBe('cu-user-123');
+  });
+});
+
+describe('login / silentSSO delegation', () => {
+  it('login returns the authorize URL without navigating (redirect:false)', async () => {
+    const c = makeClient();
+    const navigate = vi.fn();
+    const url = await c.login({ redirect: false, navigate });
+    expect(url).toContain('/oidc/auth');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('silentSSO returns the /sso/check URL', () => {
+    const c = makeClient();
+    const url = c.silentSSO({ returnUrl: 'https://app.example.com/sso/land', redirect: false });
+    expect(url).toContain('/sso/check');
+    expect(url).toContain('return=');
+  });
+});
+
+describe('logout', () => {
+  it('builds the end-session URL with id_token_hint and clears the stored token', async () => {
+    const c = makeClient();
+    const token = await signTestJwt(key, sampleClaims());
+    localStorage.setItem('cu_id_token', token);
+    const navigate = vi.fn();
+
+    const url = new URL(
+      c.logout({ postLogoutRedirectUri: 'https://app.example.com/', navigate }),
+    );
+    expect(url.origin + url.pathname).toBe('https://staging.oidc.merkos302.com/oidc/session/end');
+    expect(url.searchParams.get('id_token_hint')).toBe(token);
+    expect(url.searchParams.get('post_logout_redirect_uri')).toBe('https://app.example.com/');
+    expect(navigate).toHaveBeenCalled();
+    // stored token cleared
+    expect(c.getStoredToken()).toBeNull();
+  });
+});

--- a/src/cu-oidc/__tests__/config.test.ts
+++ b/src/cu-oidc/__tests__/config.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for cu-oidc config resolution (environment/issuer selection + endpoints).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildEndpoints, resolveCuOidcConfig, resolveIssuer } from '../config';
+import { CU_OIDC_ISSUERS } from '../types';
+
+const BASE = { clientId: 'cu-harness-consumer-b', redirectUri: 'https://app.example.com/auth/callback' };
+
+describe('resolveIssuer', () => {
+  it('defaults to staging when nothing supplied', () => {
+    expect(resolveIssuer(undefined, undefined)).toBe(CU_OIDC_ISSUERS.staging);
+  });
+
+  it('selects by environment', () => {
+    expect(resolveIssuer('production', undefined)).toBe(CU_OIDC_ISSUERS.production);
+    expect(resolveIssuer('local', undefined)).toBe(CU_OIDC_ISSUERS.local);
+  });
+
+  it('lets an explicit issuer win over environment and trims a trailing slash', () => {
+    expect(resolveIssuer('production', 'https://custom.example.com/')).toBe(
+      'https://custom.example.com',
+    );
+  });
+});
+
+describe('buildEndpoints', () => {
+  it('derives the correct absolute endpoint paths', () => {
+    const e = buildEndpoints('https://staging.oidc.merkos302.com');
+    expect(e.authorize).toBe('https://staging.oidc.merkos302.com/oidc/auth');
+    expect(e.token).toBe('https://staging.oidc.merkos302.com/oidc/token');
+    expect(e.userinfo).toBe('https://staging.oidc.merkos302.com/oidc/me');
+    expect(e.endSession).toBe('https://staging.oidc.merkos302.com/oidc/session/end');
+    expect(e.jwks).toBe('https://staging.oidc.merkos302.com/.well-known/jwks.json');
+    expect(e.ssoCheck).toBe('https://staging.oidc.merkos302.com/sso/check');
+  });
+});
+
+describe('resolveCuOidcConfig', () => {
+  it('applies defaults (staging issuer, standard scope, storage keys)', () => {
+    const r = resolveCuOidcConfig(BASE);
+    expect(r.issuer).toBe(CU_OIDC_ISSUERS.staging);
+    expect(r.scope).toBe('openid email profile');
+    expect(r.storageKeyPrefix).toBe('cu_oidc_');
+    expect(r.tokenStorageKey).toBe('cu_id_token');
+    expect(r.debug).toBe(false);
+    expect(r.endpoints.token).toContain('staging.oidc.merkos302.com');
+  });
+
+  it('honors overrides', () => {
+    const r = resolveCuOidcConfig({
+      ...BASE,
+      environment: 'production',
+      scope: 'openid',
+      storageKeyPrefix: 'x_',
+      tokenStorageKey: 'my_token',
+      debug: true,
+    });
+    expect(r.issuer).toBe(CU_OIDC_ISSUERS.production);
+    expect(r.scope).toBe('openid');
+    expect(r.storageKeyPrefix).toBe('x_');
+    expect(r.tokenStorageKey).toBe('my_token');
+    expect(r.debug).toBe(true);
+  });
+
+  it('throws when clientId or redirectUri is missing', () => {
+    expect(() => resolveCuOidcConfig({ clientId: '', redirectUri: 'x' })).toThrow(/clientId/);
+    expect(() => resolveCuOidcConfig({ clientId: 'x', redirectUri: '' })).toThrow(/redirectUri/);
+  });
+});

--- a/src/cu-oidc/__tests__/crypto-utils.test.ts
+++ b/src/cu-oidc/__tests__/crypto-utils.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the framework-agnostic crypto/encoding helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  base64UrlToBytes,
+  base64UrlToString,
+  bytesToBase64Url,
+  decodeJwtHeader,
+  decodeJwtPayload,
+  randomBase64Url,
+  sha256Base64Url,
+  splitJwt,
+} from '../crypto-utils';
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('base64url encoding', () => {
+  it('round-trips arbitrary bytes', () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+    const encoded = bytesToBase64Url(bytes);
+    expect(encoded).not.toMatch(/[+/=]/); // url-safe, unpadded
+    expect(Array.from(base64UrlToBytes(encoded))).toEqual(Array.from(bytes));
+  });
+
+  it('decodes UTF-8 strings', () => {
+    const original = 'héllo wörld — שלום';
+    const encoded = bytesToBase64Url(new TextEncoder().encode(original));
+    expect(base64UrlToString(encoded)).toBe(original);
+  });
+
+  it('tolerates standard base64 (with + / and padding) input', () => {
+    // "subjects?_d" style bytes chosen to force + and / in standard base64.
+    const bytes = new Uint8Array([255, 224, 255]);
+    const standard = btoa(String.fromCharCode(...bytes)); // "/+D/"
+    expect(Array.from(base64UrlToBytes(standard))).toEqual(Array.from(bytes));
+  });
+});
+
+describe('randomBase64Url', () => {
+  it('produces a 43-char string for 32 bytes (RFC 7636 verifier length)', () => {
+    expect(randomBase64Url(32)).toHaveLength(43);
+  });
+
+  it('produces distinct values across calls', () => {
+    const values = new Set(Array.from({ length: 20 }, () => randomBase64Url(16)));
+    expect(values.size).toBe(20);
+  });
+});
+
+describe('sha256Base64Url', () => {
+  it('matches the known SHA-256 vector for "abc"', async () => {
+    const out = await sha256Base64Url('abc');
+    // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    expect(bytesToHex(base64UrlToBytes(out))).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    );
+  });
+});
+
+describe('JWT decode', () => {
+  const header = bytesToBase64Url(new TextEncoder().encode(JSON.stringify({ alg: 'RS256', kid: 'k1' })));
+  const payload = bytesToBase64Url(
+    new TextEncoder().encode(JSON.stringify({ sub: 'user-1', chabaduniverse: { is_shliach: true } })),
+  );
+  const jwt = `${header}.${payload}.sig`;
+
+  it('splits a compact JWS into three parts', () => {
+    expect(splitJwt(jwt)).toHaveLength(3);
+    expect(splitJwt('a.b')).toBeNull();
+  });
+
+  it('decodes the header', () => {
+    expect(decodeJwtHeader(jwt)).toMatchObject({ alg: 'RS256', kid: 'k1' });
+  });
+
+  it('decodes the payload', () => {
+    const claims = decodeJwtPayload(jwt);
+    expect(claims?.sub).toBe('user-1');
+    expect(claims?.chabaduniverse?.is_shliach).toBe(true);
+  });
+
+  it('returns null on malformed input', () => {
+    expect(decodeJwtPayload('garbage')).toBeNull();
+    expect(decodeJwtHeader('garbage')).toBeNull();
+  });
+});

--- a/src/cu-oidc/__tests__/jwks.test.ts
+++ b/src/cu-oidc/__tests__/jwks.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for JWKS fetch + RS256 id_token verification.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearJwksCache,
+  CuOidcVerifyError,
+  fetchJwks,
+  verifyIdToken,
+} from '../jwks';
+import { generateTestKey, sampleClaims, signTestJwt, type TestKey } from './test-helpers';
+
+const ISSUER = 'https://staging.oidc.merkos302.com';
+const JWKS_URI = `${ISSUER}/.well-known/jwks.json`;
+
+let key: TestKey;
+
+beforeEach(async () => {
+  clearJwksCache();
+  key = await generateTestKey();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('verifyIdToken — happy path', () => {
+  it('verifies a well-formed, correctly-signed token against pre-fetched JWKS', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    const claims = await verifyIdToken(token, {
+      jwksUri: JWKS_URI,
+      issuer: ISSUER,
+      jwks: key.jwks,
+    });
+    expect(claims.sub).toBe('cu-user-123');
+    expect(claims.iss).toBe(ISSUER);
+    expect(claims.chabaduniverse?.is_shliach).toBe(true);
+  });
+
+  it('fetches JWKS via injected fetch when not pre-supplied', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify(key.jwks), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const claims = await verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, fetchImpl });
+    expect(claims.sub).toBe('cu-user-123');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('verifyIdToken — sad paths', () => {
+  it('rejects a token signed by a different key (bad_signature)', async () => {
+    const otherKey = await generateTestKey('other-kid');
+    // Sign with the OTHER key but present OUR JWKS with a matching kid so key
+    // selection succeeds and the signature check is what fails.
+    const token = await signTestJwt(otherKey, sampleClaims(), { kid: key.kid });
+    await expect(
+      verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, jwks: key.jwks }),
+    ).rejects.toMatchObject({ reason: 'bad_signature' });
+  });
+
+  it('rejects an issuer mismatch (iss_mismatch)', async () => {
+    const token = await signTestJwt(key, sampleClaims({ iss: 'https://evil.example.com' }));
+    await expect(
+      verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, jwks: key.jwks }),
+    ).rejects.toMatchObject({ reason: 'iss_mismatch' });
+  });
+
+  it('rejects an expired token (expired)', async () => {
+    const past = Math.floor(Date.now() / 1000) - 7200;
+    const token = await signTestJwt(key, sampleClaims({ iat: past, exp: past + 60 }));
+    await expect(
+      verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, jwks: key.jwks }),
+    ).rejects.toMatchObject({ reason: 'expired' });
+  });
+
+  it('rejects a non-RS256 alg (unsupported_alg)', async () => {
+    const token = await signTestJwt(key, sampleClaims(), { alg: 'HS256' });
+    await expect(
+      verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, jwks: key.jwks }),
+    ).rejects.toMatchObject({ reason: 'unsupported_alg' });
+  });
+
+  it('rejects a malformed JWT (malformed_jwt)', async () => {
+    await expect(
+      verifyIdToken('not-a-jwt', { jwksUri: JWKS_URI, issuer: ISSUER, jwks: key.jwks }),
+    ).rejects.toMatchObject({ reason: 'malformed_jwt' });
+  });
+
+  it('rejects when no JWKS key matches the kid (no_matching_key)', async () => {
+    const token = await signTestJwt(key, sampleClaims(), { kid: 'unknown-kid' });
+    const emptyJwks = { keys: [] };
+    await expect(
+      verifyIdToken(token, { jwksUri: JWKS_URI, issuer: ISSUER, jwks: emptyJwks }),
+    ).rejects.toMatchObject({ reason: 'no_matching_key' });
+  });
+});
+
+describe('fetchJwks', () => {
+  it('caches results per-URL and only fetches once', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify(key.jwks), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    await fetchJwks(JWKS_URI, { fetchImpl });
+    await fetchJwks(JWKS_URI, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses the cache with forceRefresh', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify(key.jwks), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    await fetchJwks(JWKS_URI, { fetchImpl });
+    await fetchJwks(JWKS_URI, { fetchImpl, forceRefresh: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on a non-OK response (jwks_fetch_failed)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    await expect(fetchJwks(JWKS_URI, { fetchImpl })).rejects.toBeInstanceOf(CuOidcVerifyError);
+  });
+});

--- a/src/cu-oidc/__tests__/login.test.ts
+++ b/src/cu-oidc/__tests__/login.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the browser PKCE authorization-code login (start + callback + refresh).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleLoginCallback, refreshTokens, startLogin } from '../login';
+import { resolveCuOidcConfig } from '../config';
+import { clearJwksCache } from '../jwks';
+import { savePkceStash, readIdToken } from '../storage';
+import { generateTestKey, sampleClaims, signTestJwt, type TestKey } from './test-helpers';
+import type { PkceStash } from '../types';
+
+const config = resolveCuOidcConfig({
+  clientId: 'cu-harness-consumer-b',
+  redirectUri: 'https://app.example.com/auth/callback',
+  environment: 'staging',
+});
+let key: TestKey;
+
+function tokenResponse(body: Record<string, unknown>, status = 200): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+}
+
+function stashFor(state: string, nonce: string): void {
+  const stash: PkceStash = {
+    verifier: 'test-verifier',
+    nonce,
+    issuer: config.issuer,
+    redirectUri: config.redirectUri,
+    clientId: config.clientId,
+    scope: config.scope,
+    createdAt: Date.now(),
+  };
+  savePkceStash(config.storageKeyPrefix, state, stash);
+}
+
+beforeEach(async () => {
+  clearJwksCache();
+  localStorage.clear();
+  key = await generateTestKey();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('startLogin', () => {
+  it('mints PKCE, stashes it (keyed by state), and returns the authorize URL', async () => {
+    const navigate = vi.fn();
+    const url = new URL(await startLogin(config, { navigate }));
+    expect(url.origin + url.pathname).toBe('https://staging.oidc.merkos302.com/oidc/auth');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('code_challenge')).toBeTruthy();
+    const state = url.searchParams.get('state')!;
+    expect(localStorage.getItem(`cu_oidc_pkce_${state}`)).toBeTruthy();
+    expect(navigate).toHaveBeenCalledWith(url.toString());
+  });
+
+  it('does not navigate when redirect:false', async () => {
+    const navigate = vi.fn();
+    await startLogin(config, { redirect: false, navigate });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleLoginCallback', () => {
+  it('exchanges the code, verifies the id_token, persists it, and returns claims + tokens', async () => {
+    const state = 'S1';
+    const nonce = 'N1';
+    stashFor(state, nonce);
+    const idToken = await signTestJwt(key, sampleClaims({ nonce }));
+    const fetchImpl = tokenResponse({
+      id_token: idToken,
+      access_token: 'AT',
+      refresh_token: 'RT',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    });
+
+    const result = await handleLoginCallback(config, {
+      url: `${config.redirectUri}?code=AUTH_CODE&state=${state}`,
+      fetchImpl,
+      jwks: key.jwks,
+    });
+
+    expect(result.claims.sub).toBe('cu-user-123');
+    expect(result.tokens.access_token).toBe('AT');
+    expect(result.tokens.refresh_token).toBe('RT');
+    expect(readIdToken('cu_id_token')).toBe(idToken);
+
+    // token endpoint called with an authorization_code grant + code_verifier, no auth header
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = String((init as RequestInit).body);
+    expect(body).toContain('grant_type=authorization_code');
+    expect(body).toContain('code_verifier=test-verifier');
+    expect((init as RequestInit).headers).not.toHaveProperty('Authorization');
+  });
+
+  it('rejects an unknown/expired state (no stash → CSRF guard)', async () => {
+    await expect(
+      handleLoginCallback(config, {
+        url: `${config.redirectUri}?code=X&state=UNKNOWN`,
+        fetchImpl: tokenResponse({}),
+        jwks: key.jwks,
+      }),
+    ).rejects.toMatchObject({ reason: 'unknown_state' });
+  });
+
+  it('rejects a nonce mismatch (replay guard)', async () => {
+    const state = 'S2';
+    stashFor(state, 'EXPECTED_NONCE');
+    const idToken = await signTestJwt(key, sampleClaims({ nonce: 'DIFFERENT_NONCE' }));
+    await expect(
+      handleLoginCallback(config, {
+        url: `${config.redirectUri}?code=X&state=${state}`,
+        fetchImpl: tokenResponse({ id_token: idToken }),
+        jwks: key.jwks,
+      }),
+    ).rejects.toMatchObject({ reason: 'nonce_mismatch' });
+  });
+
+  it('surfaces an OAuth error param', async () => {
+    await expect(
+      handleLoginCallback(config, {
+        url: `${config.redirectUri}?error=access_denied&state=S`,
+        fetchImpl: tokenResponse({}),
+      }),
+    ).rejects.toMatchObject({ reason: 'oauth_error' });
+  });
+
+  it('rejects when code or state is missing', async () => {
+    await expect(
+      handleLoginCallback(config, {
+        url: `${config.redirectUri}?state=S`,
+        fetchImpl: tokenResponse({}),
+      }),
+    ).rejects.toMatchObject({ reason: 'missing_params' });
+  });
+
+  it('surfaces a token-endpoint error response', async () => {
+    const state = 'S3';
+    stashFor(state, 'N');
+    await expect(
+      handleLoginCallback(config, {
+        url: `${config.redirectUri}?code=X&state=${state}`,
+        fetchImpl: tokenResponse({ error: 'invalid_grant' }, 400),
+        jwks: key.jwks,
+      }),
+    ).rejects.toMatchObject({ reason: 'token_endpoint_error' });
+  });
+});
+
+describe('refreshTokens', () => {
+  it('exchanges a refresh_token and persists the new id_token', async () => {
+    const idToken = await signTestJwt(key, sampleClaims());
+    const fetchImpl = tokenResponse({ id_token: idToken, refresh_token: 'RT2', access_token: 'AT2' });
+
+    const tokens = await refreshTokens(config, 'OLD_RT', { fetchImpl });
+    expect(tokens.id_token).toBe(idToken);
+    expect(readIdToken('cu_id_token')).toBe(idToken);
+
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(String((init as RequestInit).body)).toContain('grant_type=refresh_token');
+  });
+
+  it('throws when no refresh_token is supplied', async () => {
+    await expect(refreshTokens(config, '', { fetchImpl: tokenResponse({}) })).rejects.toMatchObject({
+      reason: 'no_refresh_token',
+    });
+  });
+
+  it('surfaces a failed refresh', async () => {
+    await expect(
+      refreshTokens(config, 'RT', { fetchImpl: tokenResponse({ error: 'invalid_grant' }, 400) }),
+    ).rejects.toMatchObject({ reason: 'refresh_failed' });
+  });
+});

--- a/src/cu-oidc/__tests__/pkce.test.ts
+++ b/src/cu-oidc/__tests__/pkce.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for PKCE parameter generation + authorize URL construction.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildAuthorizeUrl, generatePkceParams } from '../pkce';
+import { sha256Base64Url } from '../crypto-utils';
+import { resolveCuOidcConfig } from '../config';
+
+describe('generatePkceParams', () => {
+  it('produces a 43-char verifier, S256 method, and distinct state/nonce', async () => {
+    const p = await generatePkceParams();
+    expect(p.verifier).toHaveLength(43);
+    expect(p.method).toBe('S256');
+    expect(p.state).toBeTruthy();
+    expect(p.nonce).toBeTruthy();
+    expect(p.state).not.toBe(p.nonce);
+  });
+
+  it('derives challenge = base64url(SHA-256(verifier))', async () => {
+    const p = await generatePkceParams();
+    expect(p.challenge).toBe(await sha256Base64Url(p.verifier));
+  });
+
+  it('mints unique parameter sets across calls', async () => {
+    const [a, b] = await Promise.all([generatePkceParams(), generatePkceParams()]);
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.state).not.toBe(b.state);
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  const config = resolveCuOidcConfig({
+    clientId: 'cu-harness-consumer-b',
+    redirectUri: 'https://app.example.com/auth/callback',
+    environment: 'staging',
+  });
+
+  it('sets every required authorization-code + PKCE parameter', () => {
+    const url = new URL(
+      buildAuthorizeUrl(config, {
+        challenge: 'CHALLENGE',
+        method: 'S256',
+        state: 'STATE',
+        nonce: 'NONCE',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe('https://staging.oidc.merkos302.com/oidc/auth');
+    const q = url.searchParams;
+    expect(q.get('client_id')).toBe('cu-harness-consumer-b');
+    expect(q.get('redirect_uri')).toBe('https://app.example.com/auth/callback');
+    expect(q.get('response_type')).toBe('code');
+    expect(q.get('scope')).toBe('openid email profile');
+    expect(q.get('state')).toBe('STATE');
+    expect(q.get('nonce')).toBe('NONCE');
+    expect(q.get('code_challenge')).toBe('CHALLENGE');
+    expect(q.get('code_challenge_method')).toBe('S256');
+  });
+});

--- a/src/cu-oidc/__tests__/silent-sso.test.ts
+++ b/src/cu-oidc/__tests__/silent-sso.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the silent cross-domain SSO flow (`/sso/check`), consumer side.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleReceiver, startSilentSso } from '../silent-sso';
+import { resolveCuOidcConfig } from '../config';
+import { clearJwksCache } from '../jwks';
+import { readIdToken } from '../storage';
+import { generateTestKey, sampleClaims, signTestJwt, type TestKey } from './test-helpers';
+
+const config = resolveCuOidcConfig({
+  clientId: 'cu-harness-consumer-b',
+  redirectUri: 'https://app.example.com/auth/callback',
+  environment: 'staging',
+});
+const RECEIVER = 'https://app.example.com/sso/land';
+let key: TestKey;
+
+beforeEach(async () => {
+  clearJwksCache();
+  localStorage.clear();
+  sessionStorage.clear();
+  key = await generateTestKey();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('startSilentSso', () => {
+  it('builds a /sso/check URL with return + state and stashes the state', () => {
+    const navigate = vi.fn();
+    const url = new URL(
+      startSilentSso(config, { returnUrl: RECEIVER, navigate }),
+    );
+    expect(url.origin + url.pathname).toBe('https://staging.oidc.merkos302.com/sso/check');
+    expect(url.searchParams.get('return')).toBe(RECEIVER);
+    const state = url.searchParams.get('state');
+    expect(state).toBeTruthy();
+    // state was stashed for the receiver to compare against
+    expect(sessionStorage.getItem('cu_oidc_sso_state')).toBe(state);
+    expect(navigate).toHaveBeenCalledWith(url.toString());
+  });
+
+  it('does not navigate when redirect:false', () => {
+    const navigate = vi.fn();
+    startSilentSso(config, { returnUrl: RECEIVER, redirect: false, navigate });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleReceiver', () => {
+  it('returns no_result when the URL carries neither token nor error', async () => {
+    const r = await handleReceiver(config, { url: 'https://app.example.com/sso/land' });
+    expect(r.status).toBe('no_result');
+  });
+
+  it('authenticates on a valid token with a matching state, stores it, and cleans the URL', async () => {
+    const state = 'STATE-XYZ';
+    sessionStorage.setItem('cu_oidc_sso_state', state);
+    const token = await signTestJwt(key, sampleClaims());
+    const replaceUrl = vi.fn();
+
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?token=${encodeURIComponent(token)}&state=${state}`,
+      jwks: key.jwks,
+      replaceUrl,
+    });
+
+    expect(r.status).toBe('authenticated');
+    if (r.status === 'authenticated') {
+      expect(r.claims.sub).toBe('cu-user-123');
+      expect(r.token).toBe(token);
+    }
+    // token persisted first-party
+    expect(readIdToken('cu_id_token')).toBe(token);
+    // URL cleaned of token/state/error
+    const cleaned = new URL(replaceUrl.mock.calls[0]![0] as string);
+    expect(cleaned.searchParams.get('token')).toBeNull();
+    expect(cleaned.searchParams.get('state')).toBeNull();
+  });
+
+  it('signals not_authenticated (fall back to login) and cleans the URL', async () => {
+    const state = 'STATE-1';
+    sessionStorage.setItem('cu_oidc_sso_state', state);
+    const replaceUrl = vi.fn();
+
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?error=not_authenticated&state=${state}`,
+      replaceUrl,
+    });
+    expect(r.status).toBe('not_authenticated');
+    expect(replaceUrl).toHaveBeenCalled();
+  });
+
+  it('rejects a state mismatch (CSRF)', async () => {
+    sessionStorage.setItem('cu_oidc_sso_state', 'EXPECTED');
+    const token = await signTestJwt(key, sampleClaims());
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?token=${encodeURIComponent(token)}&state=FORGED`,
+      jwks: key.jwks,
+    });
+    expect(r).toMatchObject({ status: 'error', error: 'state_mismatch' });
+    // did NOT store the token
+    expect(readIdToken('cu_id_token')).toBeNull();
+  });
+
+  it('rejects when no state was stashed', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?token=${encodeURIComponent(token)}&state=ANY`,
+      jwks: key.jwks,
+    });
+    expect(r).toMatchObject({ status: 'error', error: 'state_mismatch' });
+  });
+
+  it('surfaces a verification failure as an error (bad signature)', async () => {
+    const state = 'STATE-BAD';
+    sessionStorage.setItem('cu_oidc_sso_state', state);
+    const otherKey = await generateTestKey('other');
+    // Token signed by other key but presenting our kid so key selection matches.
+    const token = await signTestJwt(otherKey, sampleClaims(), { kid: key.kid });
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?token=${encodeURIComponent(token)}&state=${state}`,
+      jwks: key.jwks,
+    });
+    expect(r).toMatchObject({ status: 'error', error: 'bad_signature' });
+    expect(readIdToken('cu_id_token')).toBeNull();
+  });
+
+  it('passes an unknown provider error through as error', async () => {
+    const state = 'STATE-E';
+    sessionStorage.setItem('cu_oidc_sso_state', state);
+    const r = await handleReceiver(config, {
+      url: `${RECEIVER}?error=server_error&state=${state}`,
+    });
+    expect(r).toMatchObject({ status: 'error', error: 'server_error' });
+  });
+});

--- a/src/cu-oidc/__tests__/test-helpers.ts
+++ b/src/cu-oidc/__tests__/test-helpers.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared test helpers for the cu-oidc suite — NOT a test file (no `.test`
+ * suffix, so vitest's include glob skips it). Generates real RSA keypairs and
+ * signs real RS256 JWTs via WebCrypto so the JWKS-verify path is exercised
+ * end-to-end (no signature-check bypass).
+ */
+
+import { bytesToBase64Url } from '../crypto-utils';
+import type { JwkSet } from '../jwks';
+import type { CuOidcClaims } from '../types';
+
+export interface TestKey {
+  keyPair: CryptoKeyPair;
+  jwks: JwkSet;
+  kid: string;
+}
+
+function strToBase64Url(s: string): string {
+  return bytesToBase64Url(new TextEncoder().encode(s));
+}
+
+/** Generate an RSA-2048 signing keypair + a matching single-key JWKS. */
+export async function generateTestKey(kid = 'test-key-1'): Promise<TestKey> {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as Record<
+    string,
+    unknown
+  >;
+  const jwks: JwkSet = {
+    keys: [{ ...publicJwk, kid, use: 'sig', alg: 'RS256' }],
+  };
+  return { keyPair, jwks, kid };
+}
+
+/** Sign a JWT (RS256) with a test key. `kid` defaults to the key's kid. */
+export async function signTestJwt(
+  key: TestKey,
+  payload: Record<string, unknown>,
+  opts: { kid?: string; alg?: string } = {},
+): Promise<string> {
+  const header = { alg: opts.alg ?? 'RS256', typ: 'JWT', kid: opts.kid ?? key.kid };
+  const h = strToBase64Url(JSON.stringify(header));
+  const p = strToBase64Url(JSON.stringify(payload));
+  const signingInput = new Uint8Array(new TextEncoder().encode(`${h}.${p}`));
+  const sig = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key.keyPair.privateKey, signingInput);
+  const s = bytesToBase64Url(new Uint8Array(sig));
+  return `${h}.${p}.${s}`;
+}
+
+/** Standard claim set with the three cu-oidc namespaces populated. */
+export function sampleClaims(overrides: Partial<CuOidcClaims> = {}): CuOidcClaims {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    sub: 'cu-user-123',
+    iss: 'https://staging.oidc.merkos302.com',
+    aud: 'cu-test-harness',
+    iat: nowSec,
+    exp: nowSec + 3600,
+    email: 'shliach@example.com',
+    email_verified: true,
+    name: 'Test Shliach',
+    chabaduniverse: {
+      user_id: 'cu-user-123',
+      via: 'magic-link',
+      is_shliach: true,
+      chabad_org_id: '770',
+    },
+    valu: { user_id: 'valu-abc' },
+    merkos: { sub: 'neo4j-uuid-xyz', shliachAccess: true },
+    ...overrides,
+  };
+}

--- a/src/cu-oidc/__tests__/useCuOidc.test.tsx
+++ b/src/cu-oidc/__tests__/useCuOidc.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for the useCuOidc React hook wrapper.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCuOidc } from '../useCuOidc';
+import { clearJwksCache } from '../jwks';
+import { generateTestKey, sampleClaims, signTestJwt, type TestKey } from './test-helpers';
+
+const CONFIG = {
+  clientId: 'cu-harness-consumer-b',
+  redirectUri: 'https://app.example.com/auth/callback',
+  environment: 'staging' as const,
+};
+let key: TestKey;
+
+beforeEach(async () => {
+  clearJwksCache();
+  localStorage.clear();
+  sessionStorage.clear();
+  key = await generateTestKey();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('useCuOidc', () => {
+  it('reflects an existing stored token on mount', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    localStorage.setItem('cu_id_token', token);
+
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    expect(result.current.token).toBe(token);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isShliach).toBe(true);
+    expect(result.current.user?.sub).toBe('cu-user-123');
+  });
+
+  it('starts unauthenticated when no token is stored', () => {
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isShliach).toBe(false);
+  });
+
+  it('landing a session via handleReceiver flips reactive state', async () => {
+    const state = 'STATE-HOOK';
+    sessionStorage.setItem('cu_oidc_sso_state', state);
+    const token = await signTestJwt(key, sampleClaims());
+
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    await act(async () => {
+      const r = await result.current.handleReceiver({
+        url: `https://app.example.com/sso/land?token=${encodeURIComponent(token)}&state=${state}`,
+        jwks: key.jwks,
+        replaceUrl: () => {},
+      });
+      expect(r.status).toBe('authenticated');
+    });
+
+    expect(result.current.token).toBe(token);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('logout clears reactive state', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    localStorage.setItem('cu_id_token', token);
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    expect(result.current.isAuthenticated).toBe(true);
+
+    act(() => {
+      result.current.logout({ navigate: () => {} });
+    });
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});

--- a/src/cu-oidc/claims.ts
+++ b/src/cu-oidc/claims.ts
@@ -1,0 +1,79 @@
+/**
+ * cu-oidc — claim accessors + token-lifecycle helpers (framework-agnostic).
+ *
+ * All accessors operate on the DECODED claim set (`decodeJwtPayload`). Decoding
+ * does not verify the signature — call `verifyIdToken` (jwks.ts) before trusting
+ * claims for an authorization decision.
+ */
+
+import { decodeJwtPayload } from './crypto-utils';
+import type {
+  CuChabaduniverseClaims,
+  CuMerkosClaims,
+  CuOidcClaims,
+  CuOidcNamespace,
+  CuValuClaims,
+} from './types';
+
+/** Decode an id_token into its structured claim set, or `null` if malformed. */
+export function getClaims(token: string): CuOidcClaims | null {
+  return decodeJwtPayload(token);
+}
+
+/** Namespace-return type helper. */
+type NamespaceValue<N extends CuOidcNamespace> = N extends 'chabaduniverse'
+  ? CuChabaduniverseClaims
+  : N extends 'valu'
+    ? CuValuClaims
+    : CuMerkosClaims;
+
+/**
+ * Read one of the three claim namespaces (`chabaduniverse` | `valu` | `merkos`)
+ * from a token or an already-decoded claim set. Returns `null` when absent.
+ */
+export function getNamespace<N extends CuOidcNamespace>(
+  source: string | CuOidcClaims | null,
+  namespace: N,
+): NamespaceValue<N> | null {
+  const claims = typeof source === 'string' ? getClaims(source) : source;
+  if (!claims) return null;
+  const value = claims[namespace];
+  if (!value || typeof value !== 'object') return null;
+  return value as NamespaceValue<N>;
+}
+
+/**
+ * Resolve shliach status from a token/claim set. Prefers the canonical
+ * `chabaduniverse.is_shliach` flag, falling back to `merkos.shliachAccess`.
+ * Returns `false` when neither is truthy.
+ */
+export function getShliachStatus(source: string | CuOidcClaims | null): boolean {
+  const claims = typeof source === 'string' ? getClaims(source) : source;
+  if (!claims) return false;
+  const cu = getNamespace(claims, 'chabaduniverse');
+  if (cu && typeof cu.is_shliach === 'boolean') return cu.is_shliach;
+  const merkos = getNamespace(claims, 'merkos');
+  if (merkos && typeof merkos.shliachAccess === 'boolean') return merkos.shliachAccess;
+  return false;
+}
+
+/**
+ * The `exp` of an id_token in milliseconds since epoch, or `null` if absent /
+ * malformed.
+ */
+export function getTokenExpiration(token: string): number | null {
+  const claims = getClaims(token);
+  if (!claims || typeof claims.exp !== 'number') return null;
+  return claims.exp * 1000;
+}
+
+/**
+ * Whether an id_token is expired (or invalid). `bufferSeconds` (default 60)
+ * treats a token expiring within the window as already expired so callers
+ * refresh proactively.
+ */
+export function isTokenExpired(token: string, bufferSeconds: number = 60): boolean {
+  const expMs = getTokenExpiration(token);
+  if (expMs === null) return true;
+  return Date.now() >= expMs - bufferSeconds * 1000;
+}

--- a/src/cu-oidc/client.ts
+++ b/src/cu-oidc/client.ts
@@ -1,0 +1,188 @@
+/**
+ * cu-oidc — the composed client. `createCuOidcClient(config)` returns a small
+ * object bundling the whole surface (login, silent SSO, verify, claims, token
+ * lifecycle, logout) bound to one resolved configuration. All methods delegate
+ * to the framework-agnostic functions in the sibling modules, so tree-shaking
+ * consumers can also import those directly.
+ */
+
+import {
+  getClaims,
+  getNamespace,
+  getShliachStatus,
+  getTokenExpiration,
+  isTokenExpired,
+} from './claims';
+import { resolveCuOidcConfig } from './config';
+import { verifyIdToken, type JwkSet } from './jwks';
+import {
+  handleLoginCallback,
+  refreshTokens,
+  startLogin,
+  type HandleLoginCallbackOptions,
+  type NavigateFn,
+  type RefreshTokensOptions,
+  type StartLoginOptions,
+} from './login';
+import {
+  handleReceiver,
+  startSilentSso,
+  type HandleReceiverOptions,
+  type StartSilentSsoOptions,
+} from './silent-sso';
+import { clearIdToken, readIdToken } from './storage';
+import type {
+  CuOidcClaims,
+  CuOidcConfig,
+  CuOidcLoginResult,
+  CuOidcNamespace,
+  CuOidcSilentResult,
+  CuOidcTokens,
+  ResolvedCuOidcConfig,
+} from './types';
+
+/** Options for {@link CuOidcClient.verify}. */
+export interface ClientVerifyOptions {
+  jwks?: JwkSet;
+  fetchImpl?: typeof fetch;
+  clockToleranceSec?: number;
+}
+
+/** Options for {@link CuOidcClient.logout}. */
+export interface LogoutOptions {
+  /** `post_logout_redirect_uri` sent to `/oidc/session/end`. */
+  postLogoutRedirectUri?: string;
+  /** `id_token_hint`. Defaults to the stored id_token when present. */
+  idTokenHint?: string;
+  /** Opaque `state` echoed back after logout. */
+  state?: string;
+  /** When `false`, return the end-session URL instead of navigating. Default `true`. */
+  redirect?: boolean;
+  /** Custom navigation (defaults to `window.location.assign`). */
+  navigate?: NavigateFn;
+  /** Clear the first-party stored id_token (default `true`). */
+  clearStored?: boolean;
+}
+
+/** The composed cu-oidc client surface. */
+export interface CuOidcClient {
+  /** The resolved configuration (issuer, endpoints, defaults applied). */
+  readonly config: ResolvedCuOidcConfig;
+
+  // --- login (authorization code + PKCE) ---
+  /** Start a login: mint PKCE, stash it, navigate to `/oidc/auth`. */
+  login(opts?: StartLoginOptions): Promise<string>;
+  /** Complete a login on the redirect-back page (code exchange + verify). */
+  handleLoginCallback(opts?: HandleLoginCallbackOptions): Promise<CuOidcLoginResult>;
+
+  // --- silent cross-domain SSO ---
+  /** Start a silent-SSO probe: navigate top-level to `/sso/check`. */
+  silentSSO(opts?: StartSilentSsoOptions): string;
+  /** Handle the silent-SSO return hop. `not_authenticated` → fall back to `login`. */
+  handleReceiver(opts?: HandleReceiverOptions): Promise<CuOidcSilentResult>;
+
+  // --- verification + claims ---
+  /** Verify a token (JWKS signature + iss + exp). Throws on failure. */
+  verify(token: string, opts?: ClientVerifyOptions): Promise<CuOidcClaims>;
+  /** Decode a token's claim set (UNVERIFIED). */
+  getClaims(token: string): CuOidcClaims | null;
+  /** Read one of the three claim namespaces. */
+  getNamespace<N extends CuOidcNamespace>(
+    source: string | CuOidcClaims | null,
+    namespace: N,
+  ): ReturnType<typeof getNamespace<N>>;
+  /** Resolve shliach status from a token/claim set. */
+  getShliachStatus(source: string | CuOidcClaims | null): boolean;
+
+  // --- token lifecycle ---
+  /** The first-party stored id_token, or `null`. */
+  getStoredToken(): string | null;
+  /** Decoded claims of the stored id_token (UNVERIFIED), or `null`. */
+  getCurrentUser(): CuOidcClaims | null;
+  /** Whether a non-expired id_token is stored first-party. */
+  isAuthenticated(bufferSeconds?: number): boolean;
+  /** Whether a token (default: the stored one) is expired/invalid. */
+  isTokenExpired(token?: string, bufferSeconds?: number): boolean;
+  /** `exp` in ms of a token (default: the stored one), or `null`. */
+  getTokenExpiration(token?: string): number | null;
+  /** Exchange a refresh_token for a fresh token set. */
+  refresh(refreshToken: string, opts?: RefreshTokensOptions): Promise<CuOidcTokens>;
+
+  // --- logout ---
+  /** Clear the stored token and navigate to `/oidc/session/end`. */
+  logout(opts?: LogoutOptions): string;
+}
+
+/** Build a cu-oidc client bound to a resolved configuration. */
+export function createCuOidcClient(config: CuOidcConfig): CuOidcClient {
+  const resolved = resolveCuOidcConfig(config);
+
+  const client: CuOidcClient = {
+    config: resolved,
+
+    login: (opts) => startLogin(resolved, opts),
+    handleLoginCallback: (opts) => handleLoginCallback(resolved, opts),
+
+    silentSSO: (opts) => startSilentSso(resolved, opts),
+    handleReceiver: (opts) => handleReceiver(resolved, opts),
+
+    verify: (token, opts = {}) =>
+      verifyIdToken(token, {
+        jwksUri: resolved.endpoints.jwks,
+        issuer: resolved.issuer,
+        ...(opts.jwks ? { jwks: opts.jwks } : {}),
+        ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+        ...(opts.clockToleranceSec !== undefined
+          ? { clockToleranceSec: opts.clockToleranceSec }
+          : {}),
+      }),
+    getClaims: (token) => getClaims(token),
+    getNamespace: (source, namespace) => getNamespace(source, namespace),
+    getShliachStatus: (source) => getShliachStatus(source),
+
+    getStoredToken: () => readIdToken(resolved.tokenStorageKey),
+    getCurrentUser: () => {
+      const token = readIdToken(resolved.tokenStorageKey);
+      return token ? getClaims(token) : null;
+    },
+    isAuthenticated: (bufferSeconds) => {
+      const token = readIdToken(resolved.tokenStorageKey);
+      return token !== null && !isTokenExpired(token, bufferSeconds);
+    },
+    isTokenExpired: (token, bufferSeconds) => {
+      const t = token ?? readIdToken(resolved.tokenStorageKey);
+      if (!t) return true;
+      return isTokenExpired(t, bufferSeconds);
+    },
+    getTokenExpiration: (token) => {
+      const t = token ?? readIdToken(resolved.tokenStorageKey);
+      return t ? getTokenExpiration(t) : null;
+    },
+    refresh: (refreshToken, opts) => refreshTokens(resolved, refreshToken, opts),
+
+    logout: (opts = {}) => {
+      const hint = opts.idTokenHint ?? readIdToken(resolved.tokenStorageKey) ?? undefined;
+      if (opts.clearStored !== false) clearIdToken(resolved.tokenStorageKey);
+
+      const u = new URL(resolved.endpoints.endSession);
+      if (hint) u.searchParams.set('id_token_hint', hint);
+      if (opts.postLogoutRedirectUri) {
+        u.searchParams.set('post_logout_redirect_uri', opts.postLogoutRedirectUri);
+      }
+      if (opts.state) u.searchParams.set('state', opts.state);
+      const url = u.toString();
+
+      if (opts.redirect !== false) {
+        const navigate: NavigateFn =
+          opts.navigate ??
+          ((target) => {
+            if (typeof window !== 'undefined') window.location.assign(target);
+          });
+        navigate(url);
+      }
+      return url;
+    },
+  };
+
+  return client;
+}

--- a/src/cu-oidc/config.ts
+++ b/src/cu-oidc/config.ts
@@ -1,0 +1,74 @@
+/**
+ * cu-oidc — config resolution: environment/issuer selection + endpoint derivation.
+ */
+
+import {
+  CU_OIDC_ISSUERS,
+  DEFAULT_CU_OIDC_ENVIRONMENT,
+  DEFAULT_CU_OIDC_SCOPE,
+  DEFAULT_STORAGE_KEY_PREFIX,
+  DEFAULT_TOKEN_STORAGE_KEY,
+  type CuOidcConfig,
+  type CuOidcEndpoints,
+  type CuOidcEnvironment,
+  type ResolvedCuOidcConfig,
+} from './types';
+
+/** Strip a single trailing slash so path concatenation is clean. */
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * Resolve the issuer base URL from an explicit `issuer` (wins) or the
+ * `environment` selector (default `'staging'`).
+ */
+export function resolveIssuer(
+  environment: CuOidcEnvironment | undefined,
+  explicitIssuer: string | undefined,
+): string {
+  if (explicitIssuer) return trimTrailingSlash(explicitIssuer);
+  const env = environment ?? DEFAULT_CU_OIDC_ENVIRONMENT;
+  const base = CU_OIDC_ISSUERS[env] ?? CU_OIDC_ISSUERS[DEFAULT_CU_OIDC_ENVIRONMENT];
+  return trimTrailingSlash(base);
+}
+
+/** Build the absolute endpoint URLs for an issuer base. */
+export function buildEndpoints(issuer: string): CuOidcEndpoints {
+  const base = trimTrailingSlash(issuer);
+  return {
+    authorize: `${base}/oidc/auth`,
+    token: `${base}/oidc/token`,
+    // node-oidc-provider default userinfo route — there is NO /oidc/userinfo.
+    userinfo: `${base}/oidc/me`,
+    endSession: `${base}/oidc/session/end`,
+    jwks: `${base}/.well-known/jwks.json`,
+    ssoCheck: `${base}/sso/check`,
+  };
+}
+
+/**
+ * Apply defaults + derive endpoints, producing the fully-resolved config the
+ * rest of the module operates on.
+ */
+export function resolveCuOidcConfig(config: CuOidcConfig): ResolvedCuOidcConfig {
+  if (!config.clientId) {
+    throw new Error('[cu-oidc] `clientId` is required.');
+  }
+  if (!config.redirectUri) {
+    throw new Error('[cu-oidc] `redirectUri` is required.');
+  }
+
+  const issuer = resolveIssuer(config.environment, config.issuer);
+
+  return {
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+    issuer,
+    scope: config.scope ?? DEFAULT_CU_OIDC_SCOPE,
+    storageKeyPrefix: config.storageKeyPrefix ?? DEFAULT_STORAGE_KEY_PREFIX,
+    tokenStorageKey: config.tokenStorageKey ?? DEFAULT_TOKEN_STORAGE_KEY,
+    debug: config.debug ?? false,
+    endpoints: buildEndpoints(issuer),
+  };
+}

--- a/src/cu-oidc/crypto-utils.ts
+++ b/src/cu-oidc/crypto-utils.ts
@@ -1,0 +1,109 @@
+/**
+ * cu-oidc — low-level, framework-agnostic crypto & encoding helpers.
+ *
+ * Uses only WebCrypto (`crypto.getRandomValues` / `crypto.subtle`) + `atob` /
+ * `btoa`, all of which are standard in browsers and Node 18+. No dependency on
+ * `jose` or any Node-only `crypto` module — this keeps the bundle tiny and lets
+ * the same code run in the browser (the only place these flows execute).
+ */
+
+import type { CuOidcClaims } from './types';
+
+/** JOSE header fields we read (unverified) to pick a JWKS key. */
+export interface JwtHeader {
+  alg?: string;
+  kid?: string;
+  typ?: string;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// base64url <-> bytes / string
+// ============================================================================
+
+/** Encode raw bytes as base64url (no padding). */
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) {
+    bin += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Decode a base64url (or standard base64) string to raw bytes. */
+export function base64UrlToBytes(input: string): Uint8Array<ArrayBuffer> {
+  let s = String(input).replace(/-/g, '+').replace(/_/g, '/');
+  while (s.length % 4) s += '=';
+  const bin = atob(s);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Decode a base64url string to a UTF-8 string. */
+export function base64UrlToString(input: string): string {
+  return new TextDecoder().decode(base64UrlToBytes(input));
+}
+
+// ============================================================================
+// randomness
+// ============================================================================
+
+/**
+ * Generate `nBytes` of CSPRNG randomness, base64url-encoded. A 32-byte value
+ * yields a 43-char string — within RFC 7636's 43–128 code_verifier range.
+ */
+export function randomBase64Url(nBytes: number = 32): string {
+  const a = new Uint8Array(nBytes);
+  crypto.getRandomValues(a);
+  return bytesToBase64Url(a);
+}
+
+// ============================================================================
+// SHA-256 (for the S256 PKCE challenge)
+// ============================================================================
+
+/** `base64url(SHA-256(input))` — the S256 PKCE code_challenge transform. */
+export async function sha256Base64Url(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+// ============================================================================
+// JWT decode (UNVERIFIED — signature checked separately in jwks.ts)
+// ============================================================================
+
+/** Split a compact JWS into its three segments, or `null` if malformed. */
+export function splitJwt(jwt: string): [string, string, string] | null {
+  const parts = String(jwt).split('.');
+  if (parts.length !== 3) return null;
+  return parts as [string, string, string];
+}
+
+/** Decode the JOSE header of a JWT without verifying it. */
+export function decodeJwtHeader(jwt: string): JwtHeader | null {
+  const parts = splitJwt(jwt);
+  if (!parts) return null;
+  try {
+    return JSON.parse(base64UrlToString(parts[0])) as JwtHeader;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode the payload (claim set) of a JWT WITHOUT verifying its signature.
+ * Use `verifyIdToken` (jwks.ts) before trusting these claims for auth.
+ */
+export function decodeJwtPayload(jwt: string): CuOidcClaims | null {
+  const parts = splitJwt(jwt);
+  if (!parts) return null;
+  try {
+    return JSON.parse(base64UrlToString(parts[1])) as CuOidcClaims;
+  } catch {
+    return null;
+  }
+}

--- a/src/cu-oidc/index.ts
+++ b/src/cu-oidc/index.ts
@@ -1,0 +1,113 @@
+/**
+ * cu-oidc-native mode (CU-1029) — public barrel.
+ *
+ * Speaks directly to the canonical Chabad Universe OIDC provider
+ * (`*.oidc.merkos302.com`) as a secretless public PKCE client. Ships ALONGSIDE
+ * the relay-based `../oidc` module — a consumer selects cu-oidc mode by
+ * importing from here (`@chabaduniverse/auth-sdk/cu-oidc`) or via the root
+ * `createCuOidcClient` / `useCuOidc` re-exports.
+ *
+ * Import the composed client for the common case:
+ *   const cu = createCuOidcClient({ clientId, redirectUri, environment: 'staging' });
+ *   await cu.login();                       // start PKCE auth-code
+ *   await cu.handleLoginCallback();         // on the redirect back
+ *   cu.silentSSO();                         // top-level /sso/check probe
+ *   const r = await cu.handleReceiver();    // on the return hop
+ *
+ * ...or import the granular, tree-shakeable functions directly.
+ */
+
+// --- composed client + React hook ---
+export { createCuOidcClient } from './client';
+export type { CuOidcClient, ClientVerifyOptions, LogoutOptions } from './client';
+export { useCuOidc } from './useCuOidc';
+export type { UseCuOidcReturn } from './useCuOidc';
+
+// --- config ---
+export { resolveCuOidcConfig, resolveIssuer, buildEndpoints } from './config';
+
+// --- PKCE + login ---
+export { generatePkceParams, buildAuthorizeUrl } from './pkce';
+export {
+  startLogin,
+  handleLoginCallback,
+  refreshTokens,
+  CuOidcLoginError,
+} from './login';
+export type {
+  NavigateFn,
+  StartLoginOptions,
+  HandleLoginCallbackOptions,
+  RefreshTokensOptions,
+} from './login';
+
+// --- silent SSO ---
+export { startSilentSso, handleReceiver } from './silent-sso';
+export type {
+  TopNavigateFn,
+  ReplaceUrlFn,
+  StartSilentSsoOptions,
+  HandleReceiverOptions,
+} from './silent-sso';
+
+// --- JWKS verification ---
+export {
+  verifyIdToken,
+  fetchJwks,
+  clearJwksCache,
+  CuOidcVerifyError,
+} from './jwks';
+export type { Jwk, JwkSet, VerifyOptions } from './jwks';
+
+// --- claims + token lifecycle ---
+export {
+  getClaims,
+  getNamespace,
+  getShliachStatus,
+  isTokenExpired,
+  getTokenExpiration,
+} from './claims';
+
+// --- storage helpers ---
+export {
+  storeIdToken,
+  readIdToken,
+  clearIdToken,
+} from './storage';
+
+// --- low-level crypto/encoding helpers ---
+export {
+  decodeJwtPayload,
+  decodeJwtHeader,
+  randomBase64Url,
+  sha256Base64Url,
+  bytesToBase64Url,
+  base64UrlToBytes,
+  base64UrlToString,
+} from './crypto-utils';
+export type { JwtHeader } from './crypto-utils';
+
+// --- constants + types ---
+export {
+  CU_OIDC_ISSUERS,
+  DEFAULT_CU_OIDC_ENVIRONMENT,
+  DEFAULT_CU_OIDC_SCOPE,
+  DEFAULT_STORAGE_KEY_PREFIX,
+  DEFAULT_TOKEN_STORAGE_KEY,
+} from './types';
+export type {
+  CuOidcEnvironment,
+  CuOidcEndpoints,
+  CuOidcConfig,
+  ResolvedCuOidcConfig,
+  PkceParams,
+  PkceStash,
+  CuOidcTokens,
+  CuOidcLoginResult,
+  CuOidcSilentResult,
+  CuChabaduniverseClaims,
+  CuValuClaims,
+  CuMerkosClaims,
+  CuOidcClaims,
+  CuOidcNamespace,
+} from './types';

--- a/src/cu-oidc/jwks.ts
+++ b/src/cu-oidc/jwks.ts
@@ -1,0 +1,183 @@
+/**
+ * cu-oidc — JWKS fetch + id_token verification (signature + `iss` + `exp`).
+ *
+ * cu-oidc (node-oidc-provider) signs id_tokens with RS256. Verification is done
+ * with WebCrypto (`RSASSA-PKCS1-v1_5` / SHA-256) so there is no `jose`
+ * dependency. Per the wire contract, this "trust iss + signature" check is the
+ * consumer's verification for the silent-SSO phase (the token's `aud` is the
+ * parent client, not the consumer).
+ */
+
+import { base64UrlToBytes, decodeJwtHeader, decodeJwtPayload, splitJwt } from './crypto-utils';
+import type { CuOidcClaims } from './types';
+
+/** A single JSON Web Key (RSA public key subset we consume). */
+export interface Jwk {
+  kty?: string;
+  kid?: string;
+  use?: string;
+  alg?: string;
+  n?: string;
+  e?: string;
+  [key: string]: unknown;
+}
+
+/** A JWKS document. */
+export interface JwkSet {
+  keys: Jwk[];
+}
+
+/** Thrown when id_token verification fails. `reason` is a stable machine code. */
+export class CuOidcVerifyError extends Error {
+  reason: string;
+  constructor(reason: string, message?: string) {
+    super(message ?? reason);
+    this.name = 'CuOidcVerifyError';
+    this.reason = reason;
+  }
+}
+
+/** Options for {@link verifyIdToken}. */
+export interface VerifyOptions {
+  /** JWKS endpoint URL to fetch signing keys from. */
+  jwksUri: string;
+  /** Expected `iss`. Verification rejects a token whose `iss` differs. */
+  issuer: string;
+  /** Clock-skew leeway in seconds applied to `exp`. Defaults to 60. */
+  clockToleranceSec?: number;
+  /**
+   * Optional pre-fetched JWKS (skips the network fetch — used for testing and
+   * caller-side caching).
+   */
+  jwks?: JwkSet;
+  /** Optional custom fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+}
+
+// ============================================================================
+// JWKS fetch (with a tiny in-module cache keyed by URL)
+// ============================================================================
+
+interface CacheEntry {
+  jwks: JwkSet;
+  fetchedAt: number;
+}
+const jwksCache = new Map<string, CacheEntry>();
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Fetch a JWKS document. Results are cached per-URL for 5 minutes; pass
+ * `forceRefresh` to bypass (e.g. after a `kid` miss on rotation).
+ */
+export async function fetchJwks(
+  jwksUri: string,
+  opts: { fetchImpl?: typeof fetch; forceRefresh?: boolean } = {},
+): Promise<JwkSet> {
+  const now = Date.now();
+  if (!opts.forceRefresh) {
+    const cached = jwksCache.get(jwksUri);
+    if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) return cached.jwks;
+  }
+  const doFetch = opts.fetchImpl ?? fetch;
+  const res = await doFetch(jwksUri, { headers: { Accept: 'application/json' } });
+  if (!res.ok) {
+    throw new CuOidcVerifyError('jwks_fetch_failed', `JWKS fetch returned ${res.status}`);
+  }
+  const jwks = (await res.json()) as JwkSet;
+  if (!jwks || !Array.isArray(jwks.keys)) {
+    throw new CuOidcVerifyError('jwks_malformed', 'JWKS response has no `keys` array');
+  }
+  jwksCache.set(jwksUri, { jwks, fetchedAt: now });
+  return jwks;
+}
+
+/** Clear the internal JWKS cache (test helper / manual invalidation). */
+export function clearJwksCache(): void {
+  jwksCache.clear();
+}
+
+// ============================================================================
+// Verification
+// ============================================================================
+
+function selectKey(jwks: JwkSet, kid: string | undefined): Jwk | null {
+  if (kid) {
+    const byKid = jwks.keys.find((k) => k.kid === kid);
+    if (byKid) return byKid;
+  }
+  // Fall back to the first RSA signing key when no kid is present or matched.
+  return jwks.keys.find((k) => (k.kty ?? 'RSA') === 'RSA' && k.n && k.e) ?? null;
+}
+
+async function importRsaKey(jwk: Jwk): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'jwk',
+    { kty: 'RSA', n: jwk.n, e: jwk.e, alg: 'RS256', ext: true } as JsonWebKey,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify'],
+  );
+}
+
+/**
+ * Verify an id_token end-to-end: RS256 signature against the issuer's JWKS,
+ * `iss` match, and `exp` (with clock tolerance). Returns the verified claims,
+ * or throws {@link CuOidcVerifyError}.
+ */
+export async function verifyIdToken(
+  token: string,
+  options: VerifyOptions,
+): Promise<CuOidcClaims> {
+  const parts = splitJwt(token);
+  if (!parts) throw new CuOidcVerifyError('malformed_jwt', 'Token is not a compact JWS');
+
+  const header = decodeJwtHeader(token);
+  if (!header) throw new CuOidcVerifyError('malformed_header', 'Cannot decode JOSE header');
+  if (header.alg && header.alg !== 'RS256') {
+    throw new CuOidcVerifyError('unsupported_alg', `Unsupported alg: ${header.alg}`);
+  }
+
+  const claims = decodeJwtPayload(token);
+  if (!claims) throw new CuOidcVerifyError('malformed_payload', 'Cannot decode payload');
+
+  const fetchOpt = options.fetchImpl ? { fetchImpl: options.fetchImpl } : {};
+  const jwks = options.jwks ?? (await fetchJwks(options.jwksUri, fetchOpt));
+  let jwk = selectKey(jwks, header.kid);
+  // On a kid miss with pre-fetched keys unavailable, retry once with a fresh
+  // JWKS to tolerate a signing-key rotation.
+  if (!jwk && !options.jwks) {
+    const fresh = await fetchJwks(options.jwksUri, { ...fetchOpt, forceRefresh: true });
+    jwk = selectKey(fresh, header.kid);
+  }
+  if (!jwk || !jwk.n || !jwk.e) {
+    throw new CuOidcVerifyError('no_matching_key', 'No JWKS key matched the token kid');
+  }
+
+  const key = await importRsaKey(jwk);
+  // Copy into fresh ArrayBuffer-backed views so the types satisfy `BufferSource`
+  // under `exactOptionalPropertyTypes` / the ArrayBufferLike-generic lib.
+  const signingInput = new Uint8Array(new TextEncoder().encode(`${parts[0]}.${parts[1]}`));
+  const signature = base64UrlToBytes(parts[2]);
+  const valid = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    signature,
+    signingInput,
+  );
+  if (!valid) throw new CuOidcVerifyError('bad_signature', 'Signature verification failed');
+
+  if (claims.iss !== options.issuer) {
+    throw new CuOidcVerifyError('iss_mismatch', `iss "${claims.iss}" != "${options.issuer}"`);
+  }
+
+  const tolerance = options.clockToleranceSec ?? 60;
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (typeof claims.exp !== 'number') {
+    throw new CuOidcVerifyError('missing_exp', 'Token has no numeric exp');
+  }
+  if (nowSec > claims.exp + tolerance) {
+    throw new CuOidcVerifyError('expired', 'Token is expired');
+  }
+
+  return claims;
+}

--- a/src/cu-oidc/login.ts
+++ b/src/cu-oidc/login.ts
@@ -1,0 +1,283 @@
+/**
+ * cu-oidc — browser authorization-code + PKCE login (public/secretless client).
+ *
+ * The flow spans two page loads, so it is exposed as two halves (mirroring the
+ * proven cu-auth-harness split of `app.js` + `auth/callback.js`):
+ *   1. {@link startLogin}          — mint PKCE, stash it, navigate to `/oidc/auth`.
+ *   2. {@link handleLoginCallback} — on the redirect back, exchange `code` for
+ *      tokens at `/oidc/token`, verify `nonce` + the id_token, persist it.
+ */
+
+import { getClaims } from './claims';
+import { CuOidcVerifyError, verifyIdToken, type JwkSet } from './jwks';
+import { buildAuthorizeUrl, generatePkceParams } from './pkce';
+import { consumePkceStash, prunePkceStashes, savePkceStash, storeIdToken } from './storage';
+import type {
+  CuOidcLoginResult,
+  CuOidcTokens,
+  PkceStash,
+  ResolvedCuOidcConfig,
+} from './types';
+
+/** Navigate the top-level window. Overridable for tests. */
+export type NavigateFn = (url: string) => void;
+
+const defaultNavigate: NavigateFn = (url) => {
+  if (typeof window !== 'undefined') window.location.assign(url);
+};
+
+/** Options for {@link startLogin}. */
+export interface StartLoginOptions {
+  /**
+   * When `false`, do NOT navigate — return the authorize URL for the caller to
+   * use. Default `true` (navigate the top-level window).
+   */
+  redirect?: boolean;
+  /** Custom navigation function (defaults to `window.location.assign`). */
+  navigate?: NavigateFn;
+}
+
+/**
+ * Begin a login: mint PKCE + state + nonce, stash them same-origin (keyed by
+ * state), then navigate to the authorization endpoint. Returns the authorize
+ * URL (also returned, not navigated, when `redirect: false`).
+ */
+export async function startLogin(
+  config: ResolvedCuOidcConfig,
+  opts: StartLoginOptions = {},
+): Promise<string> {
+  prunePkceStashes(config.storageKeyPrefix);
+  const pkce = await generatePkceParams();
+
+  const stash: PkceStash = {
+    verifier: pkce.verifier,
+    nonce: pkce.nonce,
+    issuer: config.issuer,
+    redirectUri: config.redirectUri,
+    clientId: config.clientId,
+    scope: config.scope,
+    createdAt: Date.now(),
+  };
+  savePkceStash(config.storageKeyPrefix, pkce.state, stash);
+
+  const url = buildAuthorizeUrl(config, pkce);
+  if (opts.redirect !== false) {
+    (opts.navigate ?? defaultNavigate)(url);
+  }
+  return url;
+}
+
+/** Options for {@link handleLoginCallback}. */
+export interface HandleLoginCallbackOptions {
+  /**
+   * The callback URL to parse (must include `?code=&state=`). Defaults to
+   * `window.location.href`.
+   */
+  url?: string;
+  /** Custom fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Pre-fetched JWKS to verify against (skips the network fetch — for tests). */
+  jwks?: JwkSet;
+  /**
+   * When `true` (default), persist the verified id_token to first-party
+   * storage under `config.tokenStorageKey`.
+   */
+  persist?: boolean;
+}
+
+/** Thrown when the login callback cannot be completed. */
+export class CuOidcLoginError extends Error {
+  reason: string;
+  detail?: unknown;
+  constructor(reason: string, message?: string, detail?: unknown) {
+    super(message ?? reason);
+    this.name = 'CuOidcLoginError';
+    this.reason = reason;
+    if (detail !== undefined) this.detail = detail;
+  }
+}
+
+function currentHref(explicit: string | undefined): string {
+  if (explicit) return explicit;
+  if (typeof window !== 'undefined') return window.location.href;
+  throw new CuOidcLoginError('no_url', 'No callback URL available (pass `url`).');
+}
+
+/**
+ * Complete a login on the redirect-back page: verify `state` (CSRF), exchange
+ * the authorization `code` at `/oidc/token` (PKCE, no secret), verify the
+ * id_token `nonce` (replay) and its signature/iss/exp, then persist it.
+ */
+export async function handleLoginCallback(
+  config: ResolvedCuOidcConfig,
+  opts: HandleLoginCallbackOptions = {},
+): Promise<CuOidcLoginResult> {
+  const href = currentHref(opts.url);
+  const parsed = new URL(href);
+  const params = parsed.searchParams;
+
+  const oauthError = params.get('error');
+  if (oauthError) {
+    throw new CuOidcLoginError('oauth_error', oauthError, {
+      error: oauthError,
+      error_description: params.get('error_description'),
+    });
+  }
+
+  const code = params.get('code');
+  const state = params.get('state');
+  if (!code || !state) {
+    throw new CuOidcLoginError('missing_params', 'Callback URL missing `code` or `state`.');
+  }
+
+  // Consume the stash (single-use). Its presence proves the `state` is one we
+  // issued — this IS the CSRF check.
+  const stash = consumePkceStash(config.storageKeyPrefix, state);
+  if (!stash) {
+    throw new CuOidcLoginError(
+      'unknown_state',
+      'Unknown or expired `state` — no matching PKCE stash. Most common cause: the ' +
+        'callback was opened in a different browser than the one that started sign-in.',
+    );
+  }
+
+  const tokens = await exchangeCode(config, code, stash, opts.fetchImpl);
+
+  // Replay defense: the id_token nonce must equal the stashed nonce.
+  const unverifiedClaims = getClaims(tokens.id_token);
+  if (!unverifiedClaims) {
+    throw new CuOidcLoginError('malformed_id_token', 'id_token is not decodable.');
+  }
+  if (stash.nonce && unverifiedClaims.nonce && unverifiedClaims.nonce !== stash.nonce) {
+    throw new CuOidcLoginError('nonce_mismatch', 'id_token nonce mismatch (possible replay).');
+  }
+
+  // Full signature/iss/exp verification.
+  let claims;
+  try {
+    claims = await verifyIdToken(tokens.id_token, {
+      jwksUri: config.endpoints.jwks,
+      issuer: config.issuer,
+      ...(opts.jwks ? { jwks: opts.jwks } : {}),
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+  } catch (e) {
+    const reason = e instanceof CuOidcVerifyError ? e.reason : 'verify_failed';
+    throw new CuOidcLoginError(reason, e instanceof Error ? e.message : String(e));
+  }
+
+  if (opts.persist !== false) {
+    storeIdToken(config.tokenStorageKey, tokens.id_token);
+  }
+
+  return { tokens, claims, issuer: config.issuer };
+}
+
+/** POST the authorization-code grant to `/oidc/token` (public client, PKCE). */
+async function exchangeCode(
+  config: ResolvedCuOidcConfig,
+  code: string,
+  stash: PkceStash,
+  fetchImpl: typeof fetch | undefined,
+): Promise<CuOidcTokens> {
+  const body = new URLSearchParams();
+  body.set('grant_type', 'authorization_code');
+  body.set('code', code);
+  body.set('redirect_uri', stash.redirectUri || config.redirectUri);
+  body.set('client_id', stash.clientId || config.clientId);
+  body.set('code_verifier', stash.verifier);
+  // NB: NO Authorization header — public client, PKCE proves possession.
+
+  const doFetch = fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(config.endpoints.token, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: body.toString(),
+    });
+  } catch (e) {
+    throw new CuOidcLoginError(
+      'token_request_failed',
+      `Token request failed: ${e instanceof Error ? e.message : String(e)}. ` +
+        `If this is a CORS error, confirm this origin is in the client's cors_origins.`,
+    );
+  }
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+
+  const tokenSet = json as Partial<CuOidcTokens>;
+  if (!res.ok || !tokenSet.id_token) {
+    throw new CuOidcLoginError('token_endpoint_error', `Token endpoint returned ${res.status}`, json);
+  }
+  return tokenSet as CuOidcTokens;
+}
+
+/** Options for {@link refreshTokens}. */
+export interface RefreshTokensOptions {
+  fetchImpl?: typeof fetch;
+  /** Persist the refreshed id_token first-party (default `true`). */
+  persist?: boolean;
+}
+
+/**
+ * Exchange a `refresh_token` for a new token set at `/oidc/token`. Persists the
+ * new id_token first-party unless `persist: false`. Does NOT re-verify the
+ * id_token — call `verify()` if you need cryptographic assurance on the result.
+ */
+export async function refreshTokens(
+  config: ResolvedCuOidcConfig,
+  refreshToken: string,
+  opts: RefreshTokensOptions = {},
+): Promise<CuOidcTokens> {
+  if (!refreshToken) {
+    throw new CuOidcLoginError('no_refresh_token', 'No refresh_token supplied.');
+  }
+  const body = new URLSearchParams();
+  body.set('grant_type', 'refresh_token');
+  body.set('refresh_token', refreshToken);
+  body.set('client_id', config.clientId);
+
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(config.endpoints.token, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: body.toString(),
+    });
+  } catch (e) {
+    throw new CuOidcLoginError(
+      'token_request_failed',
+      `Refresh request failed: ${e instanceof Error ? e.message : String(e)}.`,
+    );
+  }
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+  const tokenSet = json as Partial<CuOidcTokens>;
+  if (!res.ok || !tokenSet.id_token) {
+    throw new CuOidcLoginError('refresh_failed', `Refresh returned ${res.status}`, json);
+  }
+  if (opts.persist !== false) {
+    storeIdToken(config.tokenStorageKey, tokenSet.id_token);
+  }
+  return tokenSet as CuOidcTokens;
+}

--- a/src/cu-oidc/pkce.ts
+++ b/src/cu-oidc/pkce.ts
@@ -1,0 +1,41 @@
+/**
+ * cu-oidc — PKCE parameter generation + authorization URL construction.
+ *
+ * cu-oidc enforces PKCE S256 provider-wide, so this is the ONLY supported
+ * transform. All values come from WebCrypto (`crypto-utils`).
+ */
+
+import { randomBase64Url, sha256Base64Url } from './crypto-utils';
+import type { PkceParams, ResolvedCuOidcConfig } from './types';
+
+/**
+ * Mint a fresh PKCE parameter set: a 32-byte `verifier` (43-char base64url),
+ * its S256 `challenge`, plus opaque `state` (CSRF) and `nonce` (id_token replay).
+ */
+export async function generatePkceParams(): Promise<PkceParams> {
+  const verifier = randomBase64Url(32);
+  const state = randomBase64Url(16);
+  const nonce = randomBase64Url(16);
+  const challenge = await sha256Base64Url(verifier);
+  return { verifier, challenge, method: 'S256', state, nonce };
+}
+
+/**
+ * Build the `/oidc/auth` authorization-code request URL for a PKCE public
+ * client from resolved config + a minted parameter set.
+ */
+export function buildAuthorizeUrl(
+  config: ResolvedCuOidcConfig,
+  pkce: Pick<PkceParams, 'challenge' | 'method' | 'state' | 'nonce'>,
+): string {
+  const u = new URL(config.endpoints.authorize);
+  u.searchParams.set('client_id', config.clientId);
+  u.searchParams.set('redirect_uri', config.redirectUri);
+  u.searchParams.set('response_type', 'code');
+  u.searchParams.set('scope', config.scope);
+  u.searchParams.set('state', pkce.state);
+  u.searchParams.set('nonce', pkce.nonce);
+  u.searchParams.set('code_challenge', pkce.challenge);
+  u.searchParams.set('code_challenge_method', pkce.method);
+  return u.toString();
+}

--- a/src/cu-oidc/silent-sso.ts
+++ b/src/cu-oidc/silent-sso.ts
@@ -1,0 +1,174 @@
+/**
+ * cu-oidc — silent cross-domain SSO (`/sso/check`), consumer side.
+ *
+ * Two halves per the wire contract:
+ *   1. {@link startSilentSso}   — top-level navigation to
+ *      `<issuer>/sso/check?return=<receiver>&state=<opaque>`. NOT a fetch, NOT
+ *      an iframe: cu-oidc must run first-party to read its `cu_id_token` cookie.
+ *   2. {@link handleReceiver}   — on the return hop, capture `token`/`error`/
+ *      `state`, verify `state` (CSRF), `history.replaceState` the token out of
+ *      the URL, JWKS-verify the JWT, and store it first-party. On
+ *      `error=not_authenticated` the caller should fall back to `startLogin`.
+ */
+
+import { CuOidcVerifyError, verifyIdToken, type JwkSet } from './jwks';
+import { randomBase64Url } from './crypto-utils';
+import { consumeSsoState, saveSsoState, storeIdToken } from './storage';
+import type { CuOidcSilentResult, ResolvedCuOidcConfig } from './types';
+
+/** Navigate the TOP-LEVEL window (breaks out of an iframe). Overridable for tests. */
+export type TopNavigateFn = (url: string) => void;
+
+const defaultTopNavigate: TopNavigateFn = (url) => {
+  if (typeof window === 'undefined') return;
+  // Assigning window.top.location.href is a permitted cross-origin navigation
+  // (reading it is not). Fall back to same-window when top is inaccessible.
+  try {
+    if (window.top && window.top !== window) {
+      window.top.location.href = url;
+      return;
+    }
+  } catch {
+    /* cross-origin top with a hostile ancestor — fall through */
+  }
+  window.location.href = url;
+};
+
+/** Options for {@link startSilentSso}. */
+export interface StartSilentSsoOptions {
+  /**
+   * The receiver URL cu-oidc redirects back to with the token. Defaults to the
+   * current page (`window.location.href`). MUST be an origin the provider's
+   * `SSO_CHECK_ALLOWED_RETURNS` allowlist accepts, or `/sso/check` returns 400.
+   */
+  returnUrl?: string;
+  /** When `false`, return the URL instead of navigating. Default `true`. */
+  redirect?: boolean;
+  /** Custom top-level navigation (defaults to navigating `window.top`). */
+  navigate?: TopNavigateFn;
+}
+
+function currentHref(): string {
+  if (typeof window !== 'undefined') return window.location.href;
+  throw new Error('[cu-oidc] startSilentSso needs a `returnUrl` outside the browser.');
+}
+
+/**
+ * Begin a silent-SSO probe: stash an opaque `state`, build the `/sso/check`
+ * URL, and navigate the top-level window to it. Returns the URL (also returned,
+ * not navigated, when `redirect: false`).
+ */
+export function startSilentSso(
+  config: ResolvedCuOidcConfig,
+  opts: StartSilentSsoOptions = {},
+): string {
+  const returnUrl = opts.returnUrl ?? currentHref();
+  const state = randomBase64Url(16);
+  saveSsoState(config.storageKeyPrefix, state);
+
+  const u = new URL(config.endpoints.ssoCheck);
+  u.searchParams.set('return', returnUrl);
+  u.searchParams.set('state', state);
+  const url = u.toString();
+
+  if (opts.redirect !== false) {
+    (opts.navigate ?? defaultTopNavigate)(url);
+  }
+  return url;
+}
+
+/** Replace the visible URL (strip token/error/state). Overridable for tests. */
+export type ReplaceUrlFn = (url: string) => void;
+
+const defaultReplaceUrl: ReplaceUrlFn = (url) => {
+  if (typeof window !== 'undefined' && window.history) {
+    try {
+      window.history.replaceState(window.history.state, '', url);
+    } catch {
+      /* ignore — cosmetic URL cleanup only */
+    }
+  }
+};
+
+/** Options for {@link handleReceiver}. */
+export interface HandleReceiverOptions {
+  /** URL to parse (defaults to `window.location.href`). */
+  url?: string;
+  /** Custom fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Pre-fetched JWKS to verify against (skips network fetch — for tests). */
+  jwks?: JwkSet;
+  /** Persist the verified token first-party (default `true`). */
+  persist?: boolean;
+  /** Custom URL replacer (defaults to `history.replaceState`). */
+  replaceUrl?: ReplaceUrlFn;
+}
+
+/**
+ * Handle the silent-SSO return hop. Returns:
+ *   - `{ status: 'authenticated', token, claims }` on a verified token,
+ *   - `{ status: 'not_authenticated' }` on `error=not_authenticated` (fall back
+ *     to `startLogin`),
+ *   - `{ status: 'no_result' }` when the URL carries neither `token` nor `error`
+ *     (this page load is not a receiver hop),
+ *   - `{ status: 'error', error }` on a state mismatch, other provider error, or
+ *     token verification failure.
+ */
+export async function handleReceiver(
+  config: ResolvedCuOidcConfig,
+  opts: HandleReceiverOptions = {},
+): Promise<CuOidcSilentResult> {
+  const href = opts.url ?? (typeof window !== 'undefined' ? window.location.href : undefined);
+  if (!href) return { status: 'no_result' };
+
+  const parsed = new URL(href);
+  const params = parsed.searchParams;
+  const token = params.get('token');
+  const error = params.get('error');
+  const returnedState = params.get('state');
+
+  // Not a receiver hop at all — leave the page untouched.
+  if (!token && !error) return { status: 'no_result' };
+
+  // CSRF: the echoed state must equal the value we stashed before redirecting.
+  const expectedState = consumeSsoState(config.storageKeyPrefix);
+  if (!expectedState || returnedState !== expectedState) {
+    // Still clean the URL so a stale/forged token isn't left visible.
+    cleanUrl(parsed, opts.replaceUrl ?? defaultReplaceUrl);
+    return { status: 'error', error: 'state_mismatch' };
+  }
+
+  // Strip token/error/state from the visible URL immediately (before any await).
+  cleanUrl(parsed, opts.replaceUrl ?? defaultReplaceUrl);
+
+  if (error) {
+    return error === 'not_authenticated'
+      ? { status: 'not_authenticated' }
+      : { status: 'error', error };
+  }
+
+  if (!token) return { status: 'error', error: 'no_token' };
+
+  try {
+    const claims = await verifyIdToken(token, {
+      jwksUri: config.endpoints.jwks,
+      issuer: config.issuer,
+      ...(opts.jwks ? { jwks: opts.jwks } : {}),
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+    if (opts.persist !== false) storeIdToken(config.tokenStorageKey, token);
+    return { status: 'authenticated', token, claims };
+  } catch (e) {
+    const reason = e instanceof CuOidcVerifyError ? e.reason : 'verify_failed';
+    return { status: 'error', error: reason };
+  }
+}
+
+/** Delete our three owned params + fragment and replace the visible URL. */
+function cleanUrl(parsed: URL, replace: ReplaceUrlFn): void {
+  parsed.searchParams.delete('token');
+  parsed.searchParams.delete('error');
+  parsed.searchParams.delete('state');
+  parsed.hash = '';
+  replace(parsed.toString());
+}

--- a/src/cu-oidc/storage.ts
+++ b/src/cu-oidc/storage.ts
@@ -1,0 +1,172 @@
+/**
+ * cu-oidc — web-storage helpers for the PKCE stash, the CSRF `state` stash,
+ * and first-party id_token persistence.
+ *
+ * Storage choice rationale (mirrors the proven cu-auth-harness):
+ *   - PKCE stash uses **localStorage** (not sessionStorage) because a magic-link
+ *     callback can land in a NEW top-level tab that does not share sessionStorage
+ *     with the tab that started the flow. localStorage is shared same-origin
+ *     across tabs. Entries are single-use (deleted on consume) and TTL-pruned.
+ *   - The silent-SSO `state` uses **sessionStorage**: the `/sso/check` round-trip
+ *     is a same-tab top-level redirect, so sessionStorage is the tighter scope
+ *     (per-tab, auto-cleared on tab close) and matches the wire contract.
+ *
+ * Every accessor is SSR-safe (no-ops when `window`/storage is unavailable).
+ */
+
+import type { PkceStash } from './types';
+
+/** TTL for a pending PKCE stash entry before it is pruned as stale. */
+const PKCE_TTL_MS = 10 * 60 * 1000;
+
+function getLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getSessionStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) return null;
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// PKCE stash (localStorage, keyed by state)
+// ============================================================================
+
+function pkceKey(prefix: string, state: string): string {
+  return `${prefix}pkce_${state}`;
+}
+
+/** Remove any PKCE stash entries older than the TTL. */
+export function prunePkceStashes(prefix: string): void {
+  const ls = getLocalStorage();
+  if (!ls) return;
+  const now = Date.now();
+  const marker = `${prefix}pkce_`;
+  for (let i = ls.length - 1; i >= 0; i--) {
+    const k = ls.key(i);
+    if (!k || k.indexOf(marker) !== 0) continue;
+    try {
+      const raw = ls.getItem(k);
+      const v = raw ? (JSON.parse(raw) as Partial<PkceStash>) : null;
+      if (!v || now - (v.createdAt ?? 0) > PKCE_TTL_MS) ls.removeItem(k);
+    } catch {
+      ls.removeItem(k);
+    }
+  }
+}
+
+/** Persist a PKCE stash keyed by its `state`. */
+export function savePkceStash(prefix: string, state: string, stash: PkceStash): void {
+  const ls = getLocalStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(pkceKey(prefix, state), JSON.stringify(stash));
+  } catch {
+    // storage disabled — the callback will surface the miss as an error
+  }
+}
+
+/**
+ * Read and CONSUME (single-use) the PKCE stash for a `state`. Returns `null`
+ * when absent or malformed.
+ */
+export function consumePkceStash(prefix: string, state: string): PkceStash | null {
+  const ls = getLocalStorage();
+  if (!ls) return null;
+  const key = pkceKey(prefix, state);
+  try {
+    const raw = ls.getItem(key);
+    if (!raw) return null;
+    ls.removeItem(key); // consume immediately
+    return JSON.parse(raw) as PkceStash;
+  } catch {
+    try {
+      ls.removeItem(key);
+    } catch {
+      /* ignore */
+    }
+    return null;
+  }
+}
+
+// ============================================================================
+// Silent-SSO state stash (sessionStorage)
+// ============================================================================
+
+function ssoStateKey(prefix: string): string {
+  return `${prefix}sso_state`;
+}
+
+/** Stash the opaque `state` for the `/sso/check` round-trip. */
+export function saveSsoState(prefix: string, state: string): void {
+  const ss = getSessionStorage();
+  if (!ss) return;
+  try {
+    ss.setItem(ssoStateKey(prefix), state);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Read and CONSUME (single-use) the stashed silent-SSO `state`, returning it
+ * for the caller to compare against the value echoed back in the URL.
+ */
+export function consumeSsoState(prefix: string): string | null {
+  const ss = getSessionStorage();
+  if (!ss) return null;
+  const key = ssoStateKey(prefix);
+  try {
+    const v = ss.getItem(key);
+    if (v !== null) ss.removeItem(key);
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// First-party token persistence (localStorage)
+// ============================================================================
+
+/** Persist the verified id_token first-party on the consumer's own origin. */
+export function storeIdToken(key: string, token: string): void {
+  const ls = getLocalStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(key, token);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Read the stored id_token, or `null`. */
+export function readIdToken(key: string): string | null {
+  const ls = getLocalStorage();
+  if (!ls) return null;
+  try {
+    return ls.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the stored id_token. */
+export function clearIdToken(key: string): void {
+  const ls = getLocalStorage();
+  if (!ls) return;
+  try {
+    ls.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/cu-oidc/types.ts
+++ b/src/cu-oidc/types.ts
@@ -1,0 +1,232 @@
+/**
+ * cu-oidc-native mode — types & constants (CU-1029).
+ *
+ * This module speaks directly to the canonical Chabad Universe OpenID Connect
+ * Identity Provider (`cu-oidc-provider`, issuer `*.oidc.merkos302.com`) as a
+ * secretless public PKCE client. It is the "Phase 3 flip" the relay-mode
+ * `../oidc` module's comments anticipated — but it ships ALONGSIDE relay mode,
+ * not as a replacement. A consumer opts in by importing from
+ * `@chabaduniverse/auth-sdk/cu-oidc` (or the root `createCuOidcClient`).
+ *
+ * Ground truth for the wire contract: `cu-oidc-provider` +
+ * `CU_OIDC_WIRE_CONTRACT.md`. Endpoint paths are hardcoded (NOT discovered)
+ * on purpose — cu-oidc only guarantees CORS on `/oidc/token` + `/oidc/me`,
+ * so a browser discovery fetch could be CORS-blocked.
+ */
+
+// ============================================================================
+// Environment / issuer selection
+// ============================================================================
+
+/** Deployment targets the SDK knows canonical issuer URLs for. */
+export type CuOidcEnvironment = 'staging' | 'production' | 'local';
+
+/**
+ * Canonical issuer base URLs per environment.
+ *
+ * `staging` is the default for now (CU-1029) — production cutover is gated on
+ * the pilot go-live. `local` targets a developer's cu-oidc-provider on :4070.
+ */
+export const CU_OIDC_ISSUERS: Record<CuOidcEnvironment, string> = {
+  staging: 'https://staging.oidc.merkos302.com',
+  production: 'https://oidc.merkos302.com',
+  local: 'http://localhost:4070',
+} as const;
+
+/** Default environment when none is supplied. */
+export const DEFAULT_CU_OIDC_ENVIRONMENT: CuOidcEnvironment = 'staging';
+
+/** Default OAuth scope. `openid` is mandatory for an id_token. */
+export const DEFAULT_CU_OIDC_SCOPE = 'openid email profile';
+
+/** Prefix for per-flow PKCE / state stash keys in web storage. */
+export const DEFAULT_STORAGE_KEY_PREFIX = 'cu_oidc_';
+
+/** First-party storage key the verified id_token is persisted under. */
+export const DEFAULT_TOKEN_STORAGE_KEY = 'cu_id_token';
+
+// ============================================================================
+// Endpoints
+// ============================================================================
+
+/** Resolved absolute endpoint URLs for an issuer. */
+export interface CuOidcEndpoints {
+  /** `GET <issuer>/oidc/auth` — authorization endpoint. */
+  authorize: string;
+  /** `POST <issuer>/oidc/token` — token endpoint (CORS-enabled for the client). */
+  token: string;
+  /** `GET <issuer>/oidc/me` — userinfo (node-oidc-provider default; NOT `/oidc/userinfo`). */
+  userinfo: string;
+  /** `GET <issuer>/oidc/session/end` — RP-initiated logout. */
+  endSession: string;
+  /** `GET <issuer>/.well-known/jwks.json` — signing keys. */
+  jwks: string;
+  /** `GET <issuer>/sso/check` — silent cross-domain SSO probe. */
+  ssoCheck: string;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Consumer-supplied configuration for a cu-oidc client. */
+export interface CuOidcConfig {
+  /** The public PKCE client_id registered in cu-oidc for this consumer origin. */
+  clientId: string;
+  /** Redirect URI registered for this client (e.g. `<origin>/auth/callback`). */
+  redirectUri: string;
+  /**
+   * Environment selector. Defaults to `'staging'`. Ignored when an explicit
+   * `issuer` is supplied.
+   */
+  environment?: CuOidcEnvironment;
+  /** Explicit issuer base URL override (wins over `environment`). */
+  issuer?: string;
+  /** OAuth scope. Defaults to `'openid email profile'`. */
+  scope?: string;
+  /** Prefix for PKCE/state stash keys. Defaults to `'cu_oidc_'`. */
+  storageKeyPrefix?: string;
+  /** First-party storage key for the id_token. Defaults to `'cu_id_token'`. */
+  tokenStorageKey?: string;
+  /** Enable debug logging. Defaults to `false`. */
+  debug?: boolean;
+}
+
+/** Fully-resolved configuration with defaults applied and endpoints derived. */
+export interface ResolvedCuOidcConfig {
+  clientId: string;
+  redirectUri: string;
+  issuer: string;
+  scope: string;
+  storageKeyPrefix: string;
+  tokenStorageKey: string;
+  debug: boolean;
+  endpoints: CuOidcEndpoints;
+}
+
+// ============================================================================
+// PKCE
+// ============================================================================
+
+/** A freshly-minted PKCE + CSRF/replay parameter set for one authorize request. */
+export interface PkceParams {
+  /** High-entropy `code_verifier` (base64url). */
+  verifier: string;
+  /** S256 `code_challenge` = base64url(SHA-256(verifier)). */
+  challenge: string;
+  /** Always `'S256'` — cu-oidc enforces S256 provider-wide. */
+  method: 'S256';
+  /** Opaque CSRF `state`. */
+  state: string;
+  /** Opaque `nonce` (id_token replay defense). */
+  nonce: string;
+}
+
+/**
+ * Values stashed same-origin (localStorage) between the authorize navigation
+ * and the callback code-exchange, keyed by `state`. Single-use.
+ */
+export interface PkceStash {
+  verifier: string;
+  nonce: string;
+  /** Issuer captured at authorize time so the flow can't drift mid-round-trip. */
+  issuer: string;
+  redirectUri: string;
+  clientId: string;
+  scope: string;
+  createdAt: number;
+}
+
+// ============================================================================
+// Token responses / results
+// ============================================================================
+
+/** Token set returned from `/oidc/token`. */
+export interface CuOidcTokens {
+  id_token: string;
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+/** Result of a completed authorization-code exchange (login callback). */
+export interface CuOidcLoginResult {
+  tokens: CuOidcTokens;
+  claims: CuOidcClaims;
+  issuer: string;
+}
+
+/**
+ * Result of the silent-SSO receiver hop. `not_authenticated` is the caller's
+ * cue to fall back to a full `login()`.
+ */
+export type CuOidcSilentResult =
+  | { status: 'authenticated'; token: string; claims: CuOidcClaims }
+  | { status: 'not_authenticated' }
+  | { status: 'no_result' }
+  | { status: 'error'; error: string };
+
+// ============================================================================
+// Claim shape (three namespaces) — see cu-oidc find-account.ts buildNamespaceClaims
+// ============================================================================
+
+/**
+ * `chabaduniverse` namespace — ecosystem identity + shliach status.
+ * Field names mirror cu-oidc's `buildNamespaceClaims`.
+ */
+export interface CuChabaduniverseClaims {
+  user_id?: string;
+  via?: string;
+  /** Canonical shliach flag for the id_token. */
+  is_shliach?: boolean;
+  shliach_confirmed_at?: string;
+  shliach_confirmed_via?: string;
+  sf_contact_id?: string;
+  chabad_org_id?: string | number;
+  first_name?: string;
+  last_name?: string;
+  [key: string]: unknown;
+}
+
+/** `valu` namespace — snapshotted Valu identity. */
+export interface CuValuClaims {
+  user_id?: string;
+  claims_snapshot?: unknown;
+  claims_captured_at?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * `merkos` namespace — Merkos-platform shape (byte-equivalent to the HS256
+ * merkos_token body). `sub` here is the Neo4j uuid, NOT the top-level OIDC sub.
+ */
+export interface CuMerkosClaims {
+  sub?: string;
+  shliachAccess?: boolean | null;
+  adminUser?: boolean | null;
+  claims_snapshot?: unknown;
+  claims_captured_at?: number;
+  [key: string]: unknown;
+}
+
+/** The full decoded id_token: standard OIDC top level + three namespaces. */
+export interface CuOidcClaims {
+  sub: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  iat?: number;
+  nonce?: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  chabaduniverse?: CuChabaduniverseClaims;
+  valu?: CuValuClaims;
+  merkos?: CuMerkosClaims;
+  [key: string]: unknown;
+}
+
+/** Namespace keys addressable via `getNamespace`. */
+export type CuOidcNamespace = 'chabaduniverse' | 'valu' | 'merkos';

--- a/src/cu-oidc/useCuOidc.ts
+++ b/src/cu-oidc/useCuOidc.ts
@@ -1,0 +1,185 @@
+/**
+ * useCuOidc — thin React wrapper over {@link createCuOidcClient}.
+ *
+ * The client itself is framework-agnostic; this hook adds React lifecycle:
+ * it memoizes a client from the config, reflects the first-party stored token
+ * as reactive state, and re-renders when the completion helpers land a session.
+ * All the heavy lifting stays in the core modules.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createCuOidcClient, type ClientVerifyOptions, type CuOidcClient, type LogoutOptions } from './client';
+import type { StartLoginOptions, HandleLoginCallbackOptions, RefreshTokensOptions } from './login';
+import type { StartSilentSsoOptions, HandleReceiverOptions } from './silent-sso';
+import type {
+  CuOidcClaims,
+  CuOidcConfig,
+  CuOidcLoginResult,
+  CuOidcSilentResult,
+  CuOidcTokens,
+} from './types';
+
+/** Reactive return shape of {@link useCuOidc}. */
+export interface UseCuOidcReturn {
+  /** The underlying framework-agnostic client. */
+  client: CuOidcClient;
+  /** Current first-party id_token, or `null`. */
+  token: string | null;
+  /** Decoded claims of the current token (UNVERIFIED), or `null`. */
+  user: CuOidcClaims | null;
+  /** Whether a non-expired token is stored. */
+  isAuthenticated: boolean;
+  /** Shliach status derived from the current claims. */
+  isShliach: boolean;
+  /** Whether an async operation (callback / receiver / refresh) is in flight. */
+  isLoading: boolean;
+  /** Last error message, or `null`. */
+  error: string | null;
+
+  /** Start a login (navigates to `/oidc/auth`). */
+  login: (opts?: StartLoginOptions) => Promise<string>;
+  /** Complete a login on the redirect-back page; updates state on success. */
+  handleLoginCallback: (opts?: HandleLoginCallbackOptions) => Promise<CuOidcLoginResult>;
+  /** Start a silent-SSO probe (navigates top-level to `/sso/check`). */
+  silentSSO: (opts?: StartSilentSsoOptions) => string;
+  /** Handle the silent-SSO return hop; updates state on `authenticated`. */
+  handleReceiver: (opts?: HandleReceiverOptions) => Promise<CuOidcSilentResult>;
+  /** Refresh the token set; updates state on success. */
+  refresh: (refreshToken: string, opts?: RefreshTokensOptions) => Promise<CuOidcTokens>;
+  /** Verify a token (JWKS signature + iss + exp). */
+  verify: (token: string, opts?: ClientVerifyOptions) => Promise<CuOidcClaims>;
+  /** Clear the stored token and navigate to `/oidc/session/end`. */
+  logout: (opts?: LogoutOptions) => string;
+}
+
+/**
+ * React binding for a cu-oidc client. Pass a stable config (or one whose
+ * identity-affecting fields don't churn between renders).
+ */
+export function useCuOidc(config: CuOidcConfig): UseCuOidcReturn {
+  // Rebuild the client only when identity-affecting config fields change.
+  const client = useMemo(
+    () => createCuOidcClient(config),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      config.clientId,
+      config.redirectUri,
+      config.environment,
+      config.issuer,
+      config.scope,
+      config.storageKeyPrefix,
+      config.tokenStorageKey,
+    ],
+  );
+
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mounted = useRef(true);
+
+  const sync = useCallback(() => {
+    setToken(client.getStoredToken());
+  }, [client]);
+
+  useEffect(() => {
+    mounted.current = true;
+    sync();
+    return () => {
+      mounted.current = false;
+    };
+  }, [sync]);
+
+  const user = useMemo(() => (token ? client.getClaims(token) : null), [client, token]);
+  const isAuthenticated = useMemo(
+    () => token !== null && !client.isTokenExpired(token),
+    [client, token],
+  );
+  const isShliach = useMemo(() => client.getShliachStatus(user), [client, user]);
+
+  const login = useCallback((opts?: StartLoginOptions) => client.login(opts), [client]);
+  const silentSSO = useCallback((opts?: StartSilentSsoOptions) => client.silentSSO(opts), [client]);
+  const verify = useCallback(
+    (t: string, opts?: ClientVerifyOptions) => client.verify(t, opts),
+    [client],
+  );
+
+  const logout = useCallback(
+    (opts?: LogoutOptions) => {
+      const url = client.logout(opts);
+      if (mounted.current) setToken(null);
+      return url;
+    },
+    [client],
+  );
+
+  const handleLoginCallback = useCallback(
+    async (opts?: HandleLoginCallbackOptions) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await client.handleLoginCallback(opts);
+        if (mounted.current) sync();
+        return result;
+      } catch (e) {
+        if (mounted.current) setError(e instanceof Error ? e.message : String(e));
+        throw e;
+      } finally {
+        if (mounted.current) setIsLoading(false);
+      }
+    },
+    [client, sync],
+  );
+
+  const handleReceiver = useCallback(
+    async (opts?: HandleReceiverOptions) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await client.handleReceiver(opts);
+        if (mounted.current) {
+          if (result.status === 'authenticated') sync();
+          else if (result.status === 'error') setError(result.error);
+        }
+        return result;
+      } finally {
+        if (mounted.current) setIsLoading(false);
+      }
+    },
+    [client, sync],
+  );
+
+  const refresh = useCallback(
+    async (refreshToken: string, opts?: RefreshTokensOptions) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const tokens = await client.refresh(refreshToken, opts);
+        if (mounted.current) sync();
+        return tokens;
+      } catch (e) {
+        if (mounted.current) setError(e instanceof Error ? e.message : String(e));
+        throw e;
+      } finally {
+        if (mounted.current) setIsLoading(false);
+      }
+    },
+    [client, sync],
+  );
+
+  return {
+    client,
+    token,
+    user,
+    isAuthenticated,
+    isShliach,
+    isLoading,
+    error,
+    login,
+    handleLoginCallback,
+    silentSSO,
+    handleReceiver,
+    refresh,
+    verify,
+    logout,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,41 @@ export type {
 } from './oidc';
 
 // ============================================================================
+// cu-oidc Module (cu-oidc-native mode — direct PKCE against *.oidc.merkos302.com)
+// ============================================================================
+//
+// Curated high-level surface only, to avoid name collisions with the CDSSO
+// module (`decodeJwtPayload`, `isTokenExpired`, `getTokenExpiration`). The full
+// granular, tree-shakeable API is available at the `./cu-oidc` subpath.
+
+export {
+  createCuOidcClient,
+  useCuOidc,
+  CuOidcLoginError,
+  CuOidcVerifyError,
+  CU_OIDC_ISSUERS,
+  DEFAULT_CU_OIDC_ENVIRONMENT,
+} from './cu-oidc';
+
+export type {
+  CuOidcClient,
+  UseCuOidcReturn,
+  CuOidcConfig,
+  ResolvedCuOidcConfig,
+  CuOidcEnvironment,
+  CuOidcEndpoints,
+  CuOidcTokens,
+  CuOidcLoginResult,
+  CuOidcSilentResult,
+  CuOidcClaims,
+  CuChabaduniverseClaims,
+  CuValuClaims,
+  CuMerkosClaims,
+  CuOidcNamespace,
+  PkceParams,
+} from './cu-oidc';
+
+// ============================================================================
 // Valu Module
 // ============================================================================
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     'merkos/index': 'src/merkos/index.ts',
     'valu/index': 'src/valu/index.ts',
     'oidc/index': 'src/oidc/index.ts',
+    'cu-oidc/index': 'src/cu-oidc/index.ts',
   },
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
## Summary

Adds a **cu-oidc-native mode** to `@chabaduniverse/auth-sdk` — the minimal surface a mini-app (and Figaro / `teachergpt.com`) needs to authenticate against cu-oidc and read identity. Shipped behind a new `./cu-oidc` export subpath as an additive, non-breaking change; the relay-era modes (`./oidc`, `./cdsso`) are untouched. This is the "Phase 3 flip" the SDK's own `src/oidc/types.ts` comment anticipated, now unblocked because cu-oidc is in production.

Version bumped `0.4.0 → 1.0.0-beta.1`. (npm publish is a separate gated step — needs 2FA, not done here.)

## What changed (25 files, +2908/−1)

New `src/cu-oidc/` module (12 source + 10 test files) + `package.json` (`./cu-oidc` export, version bump), `tsup.config.ts` (build entry), `src/index.ts` (curated collision-safe root re-export):

- **`pkce.ts` / `login.ts`** — `startLogin` (PKCE S256 authorize + navigate), `handleLoginCallback` (code exchange + verify + persist), `refreshTokens`
- **`silent-sso.ts`** — `startSilentSso` (top-nav `/sso/check?return=&state=`), `handleReceiver` (capture/verify `state`, `history.replaceState`, JWKS-verify, first-party store)
- **`jwks.ts`** — `fetchJwks` (5-min cache) + `verifyIdToken` (RS256 via WebCrypto; iss + exp + signature)
- **`claims.ts`** — `getClaims` / `getNamespace` / `getShliachStatus` (three-namespace accessors)
- **`crypto-utils.ts`** — base64url, CSPRNG, SHA-256, JWT decode (WebCrypto + atob/btoa; no `jose` dep)
- **`storage.ts`** — PKCE stash (localStorage, single-use, TTL-pruned), SSO-state stash (sessionStorage), first-party token persistence
- **`client.ts` / `useCuOidc.ts` / `index.ts`** — composed `createCuOidcClient()` surface + React hook + barrel

Config selects `environment: 'staging' | 'production' | 'local'` (default **staging**) or an explicit `issuer`.

## Acceptance criteria

- [x] `login()` completes a standards PKCE code-exchange against cu-oidc in-browser, no secret
- [x] `silentSSO()` drives the `/sso/check` redirect and lands a verified token in first-party storage on the consumer's own eTLD+1
- [x] id_token verified against cu-oidc JWKS (iss / exp / signature; `aud` intentionally trusted-by-iss for the silent-SSO phase per the wire contract)
- [x] `getClaims()` / `useCuOidc()` expose the three namespaces + top-level identity
- [x] Relay mode preserved (no break for the 8 existing consumers); cu-oidc mode is config-selected
- [x] Published surface as `1.0.0-beta.1` (tsup build; `./cu-oidc` subpath) — **publish itself pending 2FA**

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm test` — **483 passed / 26 files / 0 failed** (74 new cu-oidc tests; JWKS + login + silent-SSO sign **real RS256 JWTs** via WebCrypto — no signature-check bypass; existing 8-consumer suites intact)
- [x] `pnpm run build` — ESM + CJS + DTS all "Build success"; emits `dist/cu-oidc/index.{js,cjs,d.ts,d.cts}`

## Notes — base branch

Targets `main`. `origin/dev` is stale at v0.1.1 — 10 commits behind `main` (`main..dev` is empty) and missing `src/oidc/` (the relay 3-step-fallback module, v0.3.0) plus every bump to 0.4.0. `main` is the living integration + default branch here, and this work extends its 0.4.0 module set; basing on `dev` would regress the package. (Bringing `dev` current from `main` is a separate cleanup, tracked outside this PR.)

Home epic: CU-840. Closes CU-1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)