### PR TITLE
feat(cu-oidc): connect-account interstitial drive + CU-1050 completion (CU-1047/1049/1050)

### DIFF
--- a/src/cu-oidc/__tests__/connect-account.test.ts
+++ b/src/cu-oidc/__tests__/connect-account.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tier-1 tests for the cross-method identity-linking module (CU-1049).
+ *
+ * Mocked Valu token + mocked fetch + injected popup/message seams — no real
+ * shell, no network. The real-shell end-to-end (mini-app registered, aud =
+ * miniapp) is Tier-2 and cannot be exercised headlessly.
+ *
+ * Environment: happy-dom (real `window`, `MessageEvent`, `localStorage`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveCuOidcConfig } from '../config';
+import { bytesToBase64Url } from '../crypto-utils';
+import { readIdToken } from '../storage';
+import {
+  CuOidcConnectError,
+  driveInterstitial,
+  ensureLinkedSession,
+  exchangeValuToken,
+  isEnrichedClaims,
+  MSG_CONNECT_READY,
+  MSG_LINKED,
+  MSG_MAGIC_LINK_SENT,
+  MSG_VALU_TOKEN,
+  TOKEN_EXCHANGE_GRANT_TYPE,
+  VALU_IDENTITY_SUBJECT_TOKEN_TYPE,
+  type PopupLike,
+} from '../connect-account';
+
+const config = resolveCuOidcConfig({
+  clientId: 'cu-test-harness',
+  redirectUri: 'https://harness.example/auth/callback',
+  environment: 'staging',
+});
+const ISSUER_ORIGIN = new URL(config.issuer).origin; // https://staging.oidc.merkos302.com
+
+// --- helpers ----------------------------------------------------------------
+
+/** Build a decodable (UNSIGNED) JWT — getClaims only reads the payload. */
+function jwt(payload: Record<string, unknown>): string {
+  const enc = (o: unknown) => bytesToBase64Url(new TextEncoder().encode(JSON.stringify(o)));
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc(payload)}.`;
+}
+
+const nowSec = Math.floor(Date.now() / 1000);
+const THIN = jwt({
+  sub: 'valu-abc',
+  iss: config.issuer,
+  aud: 'cu-test-harness',
+  iat: nowSec,
+  exp: nowSec + 300,
+  valu: { user_id: 'valu-abc' },
+});
+const ENRICHED = jwt({
+  sub: 'cu-user-1',
+  iss: config.issuer,
+  aud: 'cu-test-harness',
+  iat: nowSec,
+  exp: nowSec + 3600,
+  email: 'shliach@example.com',
+  email_verified: true,
+  chabaduniverse: { user_id: 'cu-user-1', is_shliach: true },
+  valu: { user_id: 'valu-abc' },
+});
+
+/** A fetch mock returning a JSON body with the given status. */
+function jsonFetch(body: Record<string, unknown>, status = 200): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+}
+
+/** A minimal spy-able popup. */
+function fakePopup(): PopupLike & { postMessage: ReturnType<typeof vi.fn> } {
+  return {
+    closed: false,
+    close: vi.fn(function (this: PopupLike) {
+      this.closed = true;
+    }),
+    postMessage: vi.fn(),
+  };
+}
+
+function post(type: string, origin = ISSUER_ORIGIN): void {
+  window.dispatchEvent(new MessageEvent('message', { origin, data: { type } }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ===========================================================================
+// exchangeValuToken — RFC 8693 wire
+// ===========================================================================
+
+describe('exchangeValuToken', () => {
+  it('POSTs the RFC 8693 grant and surfaces the issued id_token from access_token', async () => {
+    let capturedBody = '';
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = String(init.body);
+      return new Response(JSON.stringify({ access_token: ENRICHED, refresh_token: 'RT', scope: 'openid' }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const { tokens, claims } = await exchangeValuToken(config, 'valu.jwt', { fetchImpl });
+
+    const params = new URLSearchParams(capturedBody);
+    expect(params.get('grant_type')).toBe(TOKEN_EXCHANGE_GRANT_TYPE);
+    expect(params.get('subject_token')).toBe('valu.jwt');
+    expect(params.get('subject_token_type')).toBe(VALU_IDENTITY_SUBJECT_TOKEN_TYPE);
+    // audience defaults to the client_id (acting client === target).
+    expect(params.get('audience')).toBe('cu-test-harness');
+    expect(params.get('client_id')).toBe('cu-test-harness');
+
+    // Issued id_token rides in access_token per §2.2 — surfaced as id_token too.
+    expect(tokens.id_token).toBe(ENRICHED);
+    expect(tokens.access_token).toBe(ENRICHED);
+    expect(tokens.refresh_token).toBe('RT');
+    expect(claims?.email).toBe('shliach@example.com');
+  });
+
+  it('honors an explicit audience override', async () => {
+    let capturedBody = '';
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = String(init.body);
+      return new Response(JSON.stringify({ access_token: THIN }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await exchangeValuToken(config, 'valu.jwt', { fetchImpl, audience: 'miniapp' });
+    expect(new URLSearchParams(capturedBody).get('audience')).toBe('miniapp');
+  });
+
+  it('throws CuOidcConnectError on a non-2xx / empty response', async () => {
+    await expect(
+      exchangeValuToken(config, 'valu.jwt', { fetchImpl: jsonFetch({ error: 'invalid_grant' }, 400) }),
+    ).rejects.toMatchObject({ name: 'CuOidcConnectError', reason: 'exchange_failed' });
+  });
+
+  it('throws when no Valu token is supplied', async () => {
+    await expect(exchangeValuToken(config, '', { fetchImpl: jsonFetch({}) })).rejects.toBeInstanceOf(
+      CuOidcConnectError,
+    );
+  });
+});
+
+// ===========================================================================
+// isEnrichedClaims — linked-vs-thin predicate
+// ===========================================================================
+
+describe('isEnrichedClaims', () => {
+  it('is true only when a non-empty top-level email is present', () => {
+    expect(isEnrichedClaims({ sub: 'x', email: 'a@b.com' })).toBe(true);
+    expect(isEnrichedClaims({ sub: 'x' })).toBe(false);
+    expect(isEnrichedClaims({ sub: 'x', email: '' })).toBe(false);
+    expect(isEnrichedClaims(null)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// driveInterstitial — popup postMessage handshake
+// ===========================================================================
+
+describe('driveInterstitial', () => {
+  it('CU-1050: hands the token over on connect-ready and resolves BOUND on cu-oidc:linked', async () => {
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', { openPopup: () => popup });
+
+    post(MSG_CONNECT_READY);
+    post(MSG_MAGIC_LINK_SENT); // intermediate — does NOT settle
+    post(MSG_LINKED); // the bind completed → terminal
+    const outcome = await p;
+
+    expect(outcome).toEqual({ status: 'bound' });
+    expect(popup.postMessage).toHaveBeenCalledWith(
+      { type: MSG_VALU_TOKEN, token: 'valu.jwt' },
+      ISSUER_ORIGIN,
+    );
+    // autoClose default — the popup is closed once the flow settles.
+    expect(popup.closed).toBe(true);
+  });
+
+  it('CU-1050: magic-link-sent is INTERMEDIATE — does not settle until linked', async () => {
+    vi.useFakeTimers();
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      // Keep all the give-up timers far out so only `linked` can settle this.
+      readyTimeoutMs: 1_000_000,
+      sentTimeoutMs: 1_000_000,
+      bindTimeoutMs: 1_000_000,
+      closePollMs: 1_000_000,
+    });
+
+    post(MSG_CONNECT_READY);
+    post(MSG_MAGIC_LINK_SENT);
+
+    // Race the still-pending promise against a sentinel — it must NOT have
+    // settled on magic-link-sent alone.
+    const sentinel = Symbol('pending');
+    const raced = await Promise.race([p, Promise.resolve(sentinel)]);
+    expect(raced).toBe(sentinel);
+
+    // Now the bind lands → BOUND.
+    post(MSG_LINKED);
+    await expect(p).resolves.toEqual({ status: 'bound' });
+  });
+
+  it('CU-1050: popup closes AFTER send (before click) → degrades to `sent`, not `dismissed`', async () => {
+    vi.useFakeTimers();
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      closePollMs: 100,
+    });
+
+    post(MSG_CONNECT_READY);
+    post(MSG_MAGIC_LINK_SENT);
+    popup.closed = true; // user closed the popup instead of clicking the link
+    vi.advanceTimersByTime(150);
+
+    await expect(p).resolves.toEqual({ status: 'sent' });
+  });
+
+  it('CU-1050: bind window elapses after send → degrades to `sent`', async () => {
+    vi.useFakeTimers();
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      bindTimeoutMs: 5000,
+    });
+
+    post(MSG_CONNECT_READY);
+    post(MSG_MAGIC_LINK_SENT);
+    vi.advanceTimersByTime(5001); // click never landed within the bind window
+
+    await expect(p).resolves.toEqual({ status: 'sent' });
+  });
+
+  it('ignores non-issuer-origin messages and hands the token over exactly once', async () => {
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', { openPopup: () => popup });
+
+    // (a) Origin guard — an attacker-origin connect-ready ALONE must not hand
+    //     over the token. Asserting BEFORE any valid ping is what actually
+    //     exercises the origin check: the tokenSent dedup would ALSO cap calls
+    //     at 1, so a test that posts a valid ping first would pass even if the
+    //     origin check were deleted. (Message dispatch is synchronous.)
+    post(MSG_CONNECT_READY, 'https://evil.example');
+    expect(popup.postMessage).not.toHaveBeenCalled();
+
+    // (a′) A `linked` from an attacker origin must NOT complete the bind either.
+    post(MSG_LINKED, 'https://evil.example');
+
+    // (b) Dedup — two legitimate re-pings (the real bridge re-pings) → the
+    //     token is handed over exactly once, to the issuer origin only.
+    post(MSG_CONNECT_READY);
+    post(MSG_CONNECT_READY);
+    post(MSG_MAGIC_LINK_SENT);
+    post(MSG_LINKED); // settle the flow
+    const outcome = await p;
+
+    expect(outcome).toEqual({ status: 'bound' });
+    expect(popup.postMessage).toHaveBeenCalledTimes(1);
+    expect(popup.postMessage).toHaveBeenCalledWith(
+      { type: MSG_VALU_TOKEN, token: 'valu.jwt' },
+      ISSUER_ORIGIN,
+    );
+  });
+
+  it('resolves blocked when the popup cannot open', async () => {
+    const outcome = await driveInterstitial(config, 'valu.jwt', { openPopup: () => null });
+    expect(outcome).toEqual({ status: 'blocked' });
+  });
+
+  it('resolves dismissed when the popup closes BEFORE sending', async () => {
+    vi.useFakeTimers();
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      closePollMs: 100,
+    });
+    popup.closed = true;
+    vi.advanceTimersByTime(150);
+    await expect(p).resolves.toEqual({ status: 'dismissed' });
+  });
+
+  it('resolves timed-out when the popup never signals ready', async () => {
+    vi.useFakeTimers();
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      readyTimeoutMs: 5000,
+    });
+    vi.advanceTimersByTime(5001);
+    await expect(p).resolves.toEqual({ status: 'timed-out' });
+  });
+});
+
+// ===========================================================================
+// ensureLinkedSession — orchestrator
+// ===========================================================================
+
+/**
+ * openPopup that drives the bridge handshake all the way to `bound` on the next
+ * tick (CU-1050 primary path — the bridge confirms the click via `cu-oidc:linked`).
+ */
+function autoBindingPopup(popup: PopupLike): () => PopupLike {
+  return () => {
+    setTimeout(() => {
+      post(MSG_CONNECT_READY);
+      post(MSG_MAGIC_LINK_SENT);
+      post(MSG_LINKED);
+    }, 0);
+    return popup;
+  };
+}
+
+/**
+ * openPopup that reaches `magic-link-sent` then closes the popup WITHOUT a
+ * `cu-oidc:linked` — the fallback path where the bridge couldn't confirm the
+ * click (older provider / click didn't land in the popup). driveInterstitial
+ * degrades to `sent`, and the orchestrator falls back to the re-exchange poll.
+ */
+function autoSentPopup(popup: PopupLike): () => PopupLike {
+  return () => {
+    setTimeout(() => {
+      post(MSG_CONNECT_READY);
+      post(MSG_MAGIC_LINK_SENT);
+      popup.closed = true; // closed after send → `sent`, not `dismissed`
+    }, 0);
+    return popup;
+  };
+}
+
+describe('ensureLinkedSession', () => {
+  it('already linked → returns the enriched token with no interstitial', async () => {
+    const openPopup = vi.fn();
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'valu.jwt',
+      fetchImpl: jsonFetch({ access_token: ENRICHED }),
+      interstitial: { openPopup },
+    });
+
+    expect(res).toMatchObject({ status: 'linked', viaInterstitial: false });
+    expect(openPopup).not.toHaveBeenCalled();
+    // Persisted first-party by default.
+    expect(readIdToken(config.tokenStorageKey)).toBe(ENRICHED);
+  });
+
+  it('CU-1050 primary path: thin → interstitial confirms bind → single re-exchange to linked', async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      const body = call === 1 ? { access_token: THIN } : { access_token: ENRICHED };
+      return new Response(JSON.stringify(body), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await ensureLinkedSession(config, {
+      getValuToken: async () => 'valu.jwt',
+      fetchImpl,
+      interstitial: { openPopup: autoBindingPopup(fakePopup()) },
+      // No poll needed on the bound path; a stub sleep would only be used by the
+      // backstop poll, which we should NOT reach here.
+      sleep: async () => {
+        throw new Error('poll must not run on the bound path');
+      },
+    });
+
+    expect(res).toMatchObject({ status: 'linked', viaInterstitial: true });
+    // Exactly two exchanges: initial (thin) + the single bound re-exchange.
+    expect(call).toBe(2);
+  });
+
+  it('CU-1050 fallback path: thin → bind unconfirmed (`sent`) → backstop poll re-exchanges to linked', async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      const body = call === 1 ? { access_token: THIN } : { access_token: ENRICHED };
+      return new Response(JSON.stringify(body), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await ensureLinkedSession(config, {
+      getValuToken: async () => 'valu.jwt',
+      fetchImpl,
+      interstitial: { openPopup: autoSentPopup(fakePopup()), closePollMs: 20 },
+      sleep: async () => {}, // no real delay between poll attempts
+    });
+
+    expect(res).toMatchObject({ status: 'linked', viaInterstitial: true });
+    // First exchange (thin) + at least one re-exchange poll (enriched).
+    expect(call).toBeGreaterThanOrEqual(2);
+  });
+
+  it('thin → user dismisses the interstitial → dismissed', async () => {
+    const popup = fakePopup();
+    const openPopup = () => {
+      setTimeout(() => {
+        popup.closed = true;
+      }, 0);
+      return popup;
+    };
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'valu.jwt',
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      interstitial: { openPopup, closePollMs: 20 },
+      sleep: async () => {},
+    });
+    expect(res).toEqual({ status: 'dismissed' });
+  });
+
+  it('thin + waitForLink:false → returns pending immediately after send (fallback path)', async () => {
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'valu.jwt',
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      interstitial: { openPopup: autoSentPopup(fakePopup()), closePollMs: 20 },
+      waitForLink: false,
+    });
+    expect(res).toEqual({ status: 'pending' });
+  });
+
+  it('throws when given neither valuToken nor getValuToken', async () => {
+    await expect(
+      ensureLinkedSession(config, { fetchImpl: jsonFetch({ access_token: THIN }) }),
+    ).rejects.toMatchObject({ name: 'CuOidcConnectError', reason: 'no_valu_token_source' });
+  });
+
+  it('static token rejected mid-poll → pending WITH lastError (not a silent false pending)', async () => {
+    // First exchange is thin; the interstitial sends; then the static token is
+    // rejected on re-exchange (expired). With no getValuToken there is nothing
+    // fresh to re-mint, so the poll must break out and surface the error rather
+    // than spin to the deadline and return a bare `pending` — which would hide
+    // a link that may already be complete server-side.
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      if (call === 1) return new Response(JSON.stringify({ access_token: THIN }), { status: 200 });
+      return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 });
+    }) as unknown as typeof fetch;
+
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'valu.jwt', // static — cannot re-mint
+      fetchImpl,
+      interstitial: { openPopup: autoSentPopup(fakePopup()), closePollMs: 20 },
+      sleep: async () => {},
+    });
+
+    expect(res.status).toBe('pending');
+    const { lastError } = res as { lastError?: CuOidcConnectError };
+    expect(lastError).toBeInstanceOf(CuOidcConnectError);
+    expect(lastError?.reason).toBe('exchange_failed');
+    // Broke on the first failed poll (1 first-exchange + 1 poll) — no spinning.
+    expect(call).toBe(2);
+  });
+});

--- a/src/cu-oidc/client.ts
+++ b/src/cu-oidc/client.ts
@@ -30,6 +30,11 @@ import {
   type HandleReceiverOptions,
   type StartSilentSsoOptions,
 } from './silent-sso';
+import {
+  ensureLinkedSession,
+  type EnsureLinkedSessionOptions,
+  type EnsureLinkedSessionResult,
+} from './connect-account';
 import { clearIdToken, readIdToken } from './storage';
 import type {
   CuOidcClaims,
@@ -81,6 +86,14 @@ export interface CuOidcClient {
   /** Handle the silent-SSO return hop. `not_authenticated` → fall back to `login`. */
   handleReceiver(opts?: HandleReceiverOptions): Promise<CuOidcSilentResult>;
 
+  // --- cross-method identity linking (CU-1049) ---
+  /**
+   * Exchange a Valu token; if the identity is thin (unlinked), drive the
+   * magic-link interstitial and re-exchange on return. Idempotent — call on
+   * every mini-app load. See {@link ensureLinkedSession}.
+   */
+  ensureLinkedSession(opts?: EnsureLinkedSessionOptions): Promise<EnsureLinkedSessionResult>;
+
   // --- verification + claims ---
   /** Verify a token (JWKS signature + iss + exp). Throws on failure. */
   verify(token: string, opts?: ClientVerifyOptions): Promise<CuOidcClaims>;
@@ -125,6 +138,8 @@ export function createCuOidcClient(config: CuOidcConfig): CuOidcClient {
 
     silentSSO: (opts) => startSilentSso(resolved, opts),
     handleReceiver: (opts) => handleReceiver(resolved, opts),
+
+    ensureLinkedSession: (opts) => ensureLinkedSession(resolved, opts),
 
     verify: (token, opts = {}) =>
       verifyIdToken(token, {

--- a/src/cu-oidc/connect-account.ts
+++ b/src/cu-oidc/connect-account.ts
@@ -1,0 +1,614 @@
+/**
+ * cu-oidc — cross-method identity linking, consumer side (CU-1049 / CU-1047).
+ *
+ * The problem: a mini-app inside the Valu shell holds a Valuverse identity
+ * token. Exchanging it at cu-oidc (RFC 8693) mints a cu-oidc token, but if
+ * this Valu identity has never been linked to a magic-link-verified email the
+ * `cu_users` row is "thin" — keyed by `valu_user_id`, no email, no SF/Neo4j
+ * enrichment. The user's enriched identity (a magic-link-first row keyed by
+ * email) exists separately and nothing joins them, because the Valu token
+ * carries no email.
+ *
+ * The fix (CU-1048 backend + this module): a self-verifying magic-link
+ * interstitial. cu-oidc hosts a page that receives the Valu token via
+ * postMessage (never a URL — it is a credential) and POSTs it same-origin
+ * alongside a typed email; clicking the magic link binds `valu sub ↔ verified
+ * email` server-side (collapsing the two rows). Afterwards a re-exchange of the
+ * SAME Valu identity returns the full enriched token.
+ *
+ * This module is the mini-app half:
+ *   - {@link exchangeValuToken}   — the RFC 8693 token-exchange call.
+ *   - {@link driveInterstitial}   — open cu-oidc's `/oidc/connect-account`
+ *     popup and hand it the Valu token via the postMessage handshake that
+ *     `connect-account-bridge.js` implements.
+ *   - {@link ensureLinkedSession} — the orchestrator the AC asks for: exchange,
+ *     classify linked vs. thin, drive the interstitial only when thin, and
+ *     re-exchange on return. Idempotent — safe to call on every mini-app load.
+ *
+ * Transport rationale: cu-oidc's magic-link request endpoint is same-origin
+ * only (`credentials-email-request.ts` requires `Origin === issuer` and never
+ * grants CORS), so the SDK cannot POST the token cross-origin. The hosted page
+ * bridges that boundary. See `cu-oidc-provider` `connect-account-page.ts`.
+ */
+
+import { getClaims } from './claims';
+import { storeIdToken } from './storage';
+import type { CuOidcClaims, CuOidcTokens, ResolvedCuOidcConfig } from './types';
+
+// ============================================================================
+// Wire constants — mirror the provider so a rename can't drift silently.
+// ============================================================================
+
+/** RFC 8693 grant type. Mirrors cu-oidc `token-exchange-grant.ts`. */
+export const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange';
+/** The only `subject_token_type` cu-oidc admits today (Valuverse identity token). */
+export const VALU_IDENTITY_SUBJECT_TOKEN_TYPE = 'urn:valuverse:identity-token';
+/** Issued-token type cu-oidc returns (the exchanged id_token). */
+export const ID_TOKEN_ISSUED_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
+/** Path of the cu-oidc-hosted interstitial page (relative to the issuer). */
+export const CONNECT_ACCOUNT_PATH = '/oidc/connect-account';
+
+/** postMessage protocol — mirrors `connect-account-bridge.js`. */
+export const MSG_CONNECT_READY = 'cu-oidc:connect-ready';
+export const MSG_VALU_TOKEN = 'cu-oidc:valu-token';
+export const MSG_MAGIC_LINK_SENT = 'cu-oidc:magic-link-sent';
+/**
+ * CU-1050 — the bridge fires this once the co-presentation bind completes
+ * (the magic-link click set the proof cookie in the popup's browser and the
+ * bridge's same-origin `/complete-bind` poll returned `{status:'bound'}`).
+ * This is the TERMINAL success signal; `magic-link-sent` is now intermediate.
+ */
+export const MSG_LINKED = 'cu-oidc:linked';
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/** Thrown when the linking flow cannot proceed. Mirrors {@link CuOidcLoginError}. */
+export class CuOidcConnectError extends Error {
+  reason: string;
+  detail?: unknown;
+  constructor(reason: string, message?: string, detail?: unknown) {
+    super(message ?? reason);
+    this.name = 'CuOidcConnectError';
+    this.reason = reason;
+    if (detail !== undefined) this.detail = detail;
+  }
+}
+
+// ============================================================================
+// Token exchange (RFC 8693)
+// ============================================================================
+
+/** Options for {@link exchangeValuToken}. */
+export interface ExchangeValuTokenOptions {
+  /**
+   * Target `audience` — the cu-oidc client_id the issued id_token's `aud` binds
+   * to. In the common mini-app pattern (acting client === target) this equals
+   * `config.clientId`, which is the default. The Valu subject_token's own `aud`
+   * must equal this (or this must be on the acting client's
+   * `token_exchange_audiences`), or cu-oidc rejects the exchange.
+   */
+  audience?: string;
+  /** Requested scope. Defaults to the config scope. */
+  scope?: string;
+  /** Custom fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+}
+
+/** Result of a token-exchange: the token set plus its decoded (UNVERIFIED) claims. */
+export interface ExchangeResult {
+  tokens: CuOidcTokens;
+  /** Decoded id_token claims, or `null` if the id_token was malformed. */
+  claims: CuOidcClaims | null;
+}
+
+/**
+ * Exchange a Valuverse identity token for a cu-oidc token set at `/oidc/token`
+ * (RFC 8693). Public/secretless — no Authorization header; possession of the
+ * signed Valu token is the proof. The issued id_token is carried in the
+ * response `access_token` field per RFC 8693 §2.2; we surface it as
+ * `tokens.id_token` too so downstream code can treat it uniformly.
+ *
+ * Does NOT verify the id_token signature — the claims returned are for
+ * routing/classification only. Call `verifyIdToken` before trusting them for an
+ * authorization decision.
+ */
+export async function exchangeValuToken(
+  config: ResolvedCuOidcConfig,
+  valuToken: string,
+  opts: ExchangeValuTokenOptions = {},
+): Promise<ExchangeResult> {
+  if (!valuToken) {
+    throw new CuOidcConnectError('no_valu_token', 'No Valu identity token supplied.');
+  }
+
+  const body = new URLSearchParams();
+  body.set('grant_type', TOKEN_EXCHANGE_GRANT_TYPE);
+  body.set('subject_token', valuToken);
+  body.set('subject_token_type', VALU_IDENTITY_SUBJECT_TOKEN_TYPE);
+  body.set('audience', opts.audience || config.clientId);
+  body.set('client_id', config.clientId);
+  body.set('scope', opts.scope || config.scope);
+  // NB: NO Authorization header — the signed Valu token is the credential.
+
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(config.endpoints.token, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: body.toString(),
+    });
+  } catch (e) {
+    throw new CuOidcConnectError(
+      'exchange_request_failed',
+      `Token-exchange request failed: ${e instanceof Error ? e.message : String(e)}. ` +
+        `If this is a CORS error, confirm this origin is in the client's cors_origins.`,
+    );
+  }
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+
+  const payload = json as {
+    access_token?: string;
+    refresh_token?: string;
+    token_type?: string;
+    expires_in?: number;
+    scope?: string;
+    issued_token_type?: string;
+  };
+
+  // RFC 8693 §2.2: the issued id_token rides in `access_token`.
+  const issued = payload.access_token;
+  if (!res.ok || !issued) {
+    throw new CuOidcConnectError('exchange_failed', `Token endpoint returned ${res.status}`, json);
+  }
+
+  const tokens: CuOidcTokens = {
+    id_token: issued,
+    access_token: issued,
+    ...(payload.refresh_token ? { refresh_token: payload.refresh_token } : {}),
+    ...(payload.token_type ? { token_type: payload.token_type } : {}),
+    ...(payload.expires_in !== undefined ? { expires_in: payload.expires_in } : {}),
+    ...(payload.scope ? { scope: payload.scope } : {}),
+  };
+
+  return { tokens, claims: getClaims(issued) };
+}
+
+// ============================================================================
+// Linked-vs-thin classification
+// ============================================================================
+
+/**
+ * Default "is this identity linked?" predicate. The interstitial exists to bind
+ * a magic-link-VERIFIED email to the Valu sub, and a thin (unlinked) row has no
+ * email — so a top-level `email` is the crispest, most robust signal that the
+ * join has happened. A magic-link-first row always carries email; a Valu-first
+ * row gains it only after the collapse. Override via
+ * {@link EnsureLinkedSessionOptions.isLinked} if a consumer needs a stricter
+ * bar (e.g. also requiring `chabaduniverse.sf_contact_id`).
+ */
+export function isEnrichedClaims(claims: CuOidcClaims | null): boolean {
+  return !!claims && typeof claims.email === 'string' && claims.email.length > 0;
+}
+
+// ============================================================================
+// Interstitial popup handshake
+// ============================================================================
+
+/** The minimal popup surface {@link driveInterstitial} needs (test-injectable). */
+export interface PopupLike {
+  closed: boolean;
+  close(): void;
+  postMessage(message: unknown, targetOrigin: string): void;
+}
+
+/** Opens the interstitial popup. Defaults to a centered `window.open`. */
+export type OpenPopupFn = (url: string, name: string, features: string) => PopupLike | null;
+
+/** The minimal message-target surface (test-injectable; defaults to `window`). */
+export interface MessageTargetLike {
+  addEventListener(type: 'message', handler: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', handler: (event: MessageEvent) => void): void;
+}
+
+/** Options for {@link driveInterstitial}. */
+export interface DriveInterstitialOptions {
+  /** Custom popup opener (defaults to a centered `window.open`). */
+  openPopup?: OpenPopupFn;
+  /** Where to listen for the popup's messages (defaults to `window`). */
+  messageTarget?: MessageTargetLike;
+  /**
+   * Max wait for the popup's first `connect-ready` ping before giving up
+   * (`timed-out`). The bridge re-pings for ~6s, so this only fires if the popup
+   * never loads. Default 15000ms.
+   */
+  readyTimeoutMs?: number;
+  /**
+   * Max wait for `magic-link-sent` after the token is handed over (the user is
+   * typing their email). Default 300000ms (5 min).
+   */
+  sentTimeoutMs?: number;
+  /**
+   * CU-1050 — after `magic-link-sent`, max wait for the bridge's `cu-oidc:linked`
+   * signal (the user opening the emailed link and the bridge's same-origin
+   * `/complete-bind` poll binding). If it elapses the outcome degrades to
+   * `{status:'sent'}` so the caller can fall back to re-exchange polling.
+   * Bounded by the Valu token's ~5-min TTL (the bridge polls with the held
+   * token). Default 300000ms (5 min).
+   */
+  bindTimeoutMs?: number;
+  /** How often to poll `popup.closed`. Default 500ms. */
+  closePollMs?: number;
+  /** Close the popup ourselves once the outcome is decided. Default `true`. */
+  autoClose?: boolean;
+}
+
+/** Terminal outcome of the interstitial popup handshake. */
+export type InterstitialOutcome =
+  /**
+   * CU-1050 — the bridge completed the co-presentation bind (the magic link
+   * was clicked in the popup's browser and the bridge's same-origin
+   * `/complete-bind` poll returned `bound`). The strongest signal: the identity
+   * is now linked and a single re-exchange will return the enriched token.
+   */
+  | { status: 'bound' }
+  /**
+   * The user submitted their email; cu-oidc accepted it and sent the magic link.
+   * INTERMEDIATE under CU-1050 — the bind only completes on click. This is
+   * returned as a terminal outcome only when the bridge closed / the bind window
+   * elapsed before the click landed; the caller should fall back to polling.
+   */
+  | { status: 'sent' }
+  /** The popup closed before the magic link was sent (user cancelled). */
+  | { status: 'dismissed' }
+  /** `window.open` returned null — popup blocked. */
+  | { status: 'blocked' }
+  /** The popup never signalled ready / never sent within the timeouts. */
+  | { status: 'timed-out' };
+
+const DEFAULT_POPUP_FEATURES = (() => {
+  const w = 460;
+  const h = 620;
+  if (typeof window === 'undefined') return `width=${w},height=${h},popup=yes`;
+  const left = window.screenX + Math.max(0, (window.innerWidth - w) / 2);
+  const top = window.screenY + Math.max(0, (window.innerHeight - h) / 2);
+  return `width=${w},height=${h},left=${left},top=${top},popup=yes`;
+})();
+
+const defaultOpenPopup: OpenPopupFn = (url, name, features) => {
+  if (typeof window === 'undefined') return null;
+  return window.open(url, name, features) as unknown as PopupLike | null;
+};
+
+/**
+ * Open cu-oidc's `/oidc/connect-account` popup and run the postMessage
+ * handshake with `connect-account-bridge.js`:
+ *
+ *   1. We open the popup and listen for messages from the ISSUER origin only.
+ *   2. The popup pings `{type:'cu-oidc:connect-ready'}`; we reply by posting
+ *      `{type:'cu-oidc:valu-token', token}` to the popup, targeted at the
+ *      issuer origin (never `'*'` — the token is a credential).
+ *   3. The popup collects the email, POSTs it same-origin, and on success
+ *      pings `{type:'cu-oidc:magic-link-sent'}` — under CU-1050 this is now
+ *      INTERMEDIATE (the bind completes only on click), so we keep waiting.
+ *   4. The user opens the emailed link in the popup's browser; the bridge's
+ *      same-origin `/complete-bind` poll co-presents the proof cookie + held
+ *      Valu token, binds, and pings `{type:'cu-oidc:linked'}` — we resolve
+ *      `{status:'bound'}`, the strongest terminal signal.
+ *
+ * Graceful degradation: if the bridge never sends `cu-oidc:linked` (older
+ * provider without the complete-bind poll, or the click didn't land before the
+ * `bindTimeoutMs` / popup-close), we resolve `{status:'sent'}` so the caller
+ * falls back to re-exchange polling — which still DETECTS a completed bind even
+ * though, under CU-1050, it can't CAUSE one.
+ *
+ * Resolves (never rejects) with an {@link InterstitialOutcome}.
+ */
+export function driveInterstitial(
+  config: ResolvedCuOidcConfig,
+  valuToken: string,
+  opts: DriveInterstitialOptions = {},
+): Promise<InterstitialOutcome> {
+  const issuerOrigin = new URL(config.issuer).origin;
+  const pageUrl = `${config.issuer}${CONNECT_ACCOUNT_PATH}`;
+  const openPopup = opts.openPopup ?? defaultOpenPopup;
+  const target: MessageTargetLike | undefined =
+    opts.messageTarget ?? (typeof window !== 'undefined' ? window : undefined);
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 15_000;
+  const sentTimeoutMs = opts.sentTimeoutMs ?? 300_000;
+  const bindTimeoutMs = opts.bindTimeoutMs ?? 300_000;
+  const closePollMs = opts.closePollMs ?? 500;
+  const autoClose = opts.autoClose !== false;
+
+  return new Promise<InterstitialOutcome>((resolve) => {
+    const popup = openPopup(pageUrl, 'cu_oidc_connect_account', DEFAULT_POPUP_FEATURES);
+    if (!popup) {
+      resolve({ status: 'blocked' });
+      return;
+    }
+    if (!target) {
+      // No window to listen on (non-browser) — nothing can complete the flow.
+      if (autoClose) safeClose(popup);
+      resolve({ status: 'timed-out' });
+      return;
+    }
+
+    let settled = false;
+    let tokenSent = false;
+    // CU-1050 — once the email is submitted the flow is "awaiting the click".
+    // A popup close or bind-timeout after this point degrades to `sent`
+    // (magic link is out; only the click hasn't landed) rather than `dismissed`.
+    let linkSent = false;
+    let readyTimer: ReturnType<typeof setTimeout> | null = null;
+    let sentTimer: ReturnType<typeof setTimeout> | null = null;
+    let bindTimer: ReturnType<typeof setTimeout> | null = null;
+    let closeTimer: ReturnType<typeof setInterval> | null = null;
+
+    const cleanup = () => {
+      target.removeEventListener('message', onMessage);
+      if (readyTimer) clearTimeout(readyTimer);
+      if (sentTimer) clearTimeout(sentTimer);
+      if (bindTimer) clearTimeout(bindTimer);
+      if (closeTimer) clearInterval(closeTimer);
+      readyTimer = sentTimer = bindTimer = null;
+      closeTimer = null;
+    };
+
+    const finish = (outcome: InterstitialOutcome) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (autoClose) safeClose(popup);
+      resolve(outcome);
+    };
+
+    const onMessage = (event: MessageEvent): void => {
+      // Only trust the cu-oidc origin. The token is a credential; nothing from
+      // another origin may drive this exchange.
+      if (event.origin !== issuerOrigin) return;
+      const data = event.data as { type?: string } | null;
+      if (!data || typeof data.type !== 'string') return;
+
+      if (data.type === MSG_CONNECT_READY) {
+        if (tokenSent) return; // bridge re-pings; hand the token over once
+        tokenSent = true;
+        if (readyTimer) {
+          clearTimeout(readyTimer);
+          readyTimer = null;
+        }
+        // Arm the "user is typing their email" window now that the page is up.
+        sentTimer = setTimeout(() => finish({ status: 'timed-out' }), sentTimeoutMs);
+        try {
+          popup.postMessage({ type: MSG_VALU_TOKEN, token: valuToken }, issuerOrigin);
+        } catch {
+          finish({ status: 'timed-out' });
+        }
+        return;
+      }
+
+      if (data.type === MSG_MAGIC_LINK_SENT) {
+        // CU-1050: INTERMEDIATE. The email is out but the bind only completes on
+        // click. Stop the "typing" timeout, arm the "awaiting click" window, and
+        // keep listening for `cu-oidc:linked`. Idempotent — the bridge could
+        // re-emit if it retries the request.
+        if (linkSent) return;
+        linkSent = true;
+        if (sentTimer) {
+          clearTimeout(sentTimer);
+          sentTimer = null;
+        }
+        bindTimer = setTimeout(() => finish({ status: 'sent' }), bindTimeoutMs);
+        return;
+      }
+
+      if (data.type === MSG_LINKED) {
+        // The bridge's same-origin /complete-bind poll bound the identity.
+        finish({ status: 'bound' });
+      }
+    };
+
+    target.addEventListener('message', onMessage);
+    readyTimer = setTimeout(() => finish({ status: 'timed-out' }), readyTimeoutMs);
+    closeTimer = setInterval(() => {
+      // Closing AFTER the email is sent isn't a cancel — the link is already
+      // out, the user just closed the popup instead of clicking in it. Degrade
+      // to `sent` so the caller polls for the bind rather than reporting a
+      // dismissal. Before send, a close is a genuine `dismissed`.
+      if (popup.closed) finish(linkSent ? { status: 'sent' } : { status: 'dismissed' });
+    }, closePollMs);
+  });
+}
+
+function safeClose(popup: PopupLike): void {
+  try {
+    if (!popup.closed) popup.close();
+  } catch {
+    /* already gone / cross-origin — nothing to do */
+  }
+}
+
+// ============================================================================
+// Orchestrator — ensureLinkedSession()
+// ============================================================================
+
+/** Options for {@link ensureLinkedSession}. */
+export interface EnsureLinkedSessionOptions {
+  /** A Valu identity token to use. Supply this OR {@link getValuToken}. */
+  valuToken?: string;
+  /**
+   * Mint/fetch a fresh Valu identity token. Preferred over a static
+   * {@link valuToken} because the re-exchange poll re-mints per attempt (Valu
+   * tokens are ~5-min TTL; a static token can expire before the user clicks).
+   */
+  getValuToken?: () => Promise<string> | string;
+  /** Target `audience` for the exchange (defaults to `config.clientId`). */
+  audience?: string;
+  /** Requested scope (defaults to the config scope). */
+  scope?: string;
+  /** Custom fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Override the linked-vs-thin predicate (default {@link isEnrichedClaims}). */
+  isLinked?: (claims: CuOidcClaims | null) => boolean;
+  /** Persist the final enriched id_token first-party (default `true`). */
+  persist?: boolean;
+  /** Popup/handshake seams passed through to {@link driveInterstitial}. */
+  interstitial?: DriveInterstitialOptions;
+  /**
+   * After the magic link is sent, poll a re-exchange until the identity links
+   * (the user clicked the link) or {@link pollTimeoutMs} elapses. Default
+   * `true`. Set `false` to return `{status:'pending'}` immediately after send
+   * and let the app re-call `ensureLinkedSession` on a later load instead.
+   */
+  waitForLink?: boolean;
+  /** Interval between re-exchange polls. Default 2500ms. */
+  pollIntervalMs?: number;
+  /** Max total time to poll for the link. Default 120000ms (2 min). */
+  pollTimeoutMs?: number;
+  /** Injectable delay (tests pass a no-op). Defaults to real `setTimeout`. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock (tests pass a fake). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Outcome of {@link ensureLinkedSession}. */
+export type EnsureLinkedSessionResult =
+  /** A full enriched token is in hand (already linked, or linked via the flow). */
+  | { status: 'linked'; tokens: CuOidcTokens; claims: CuOidcClaims | null; viaInterstitial: boolean }
+  /**
+   * Magic link sent; identity not yet linked (poll disabled, or user hasn't
+   * clicked). `lastError` is set when the poll ended because the re-exchange
+   * kept failing — with a static `valuToken` that usually means the token
+   * expired before the click, so the link may already be complete server-side:
+   * re-invoke `ensureLinkedSession` with a fresh token to confirm.
+   */
+  | { status: 'pending'; lastError?: CuOidcConnectError }
+  /** The user closed the interstitial without submitting. */
+  | { status: 'dismissed' }
+  /** The popup was blocked by the browser. */
+  | { status: 'blocked' };
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => {
+    setTimeout(r, ms);
+  });
+
+/**
+ * The AC's clean API. Exchange the Valu token, and:
+ *   - if the result is already enriched → return it (no interstitial);
+ *   - if it is thin → drive the interstitial popup, and on send re-exchange
+ *     until the identity links (or the poll times out).
+ *
+ * Idempotent: safe to call on every mini-app load. A thin identity whose user
+ * has since clicked the link returns `linked` immediately on the first
+ * exchange, with no popup. Triggering is keyed on THIN, not on
+ * no-token-in-memory, per the AC.
+ */
+export async function ensureLinkedSession(
+  config: ResolvedCuOidcConfig,
+  opts: EnsureLinkedSessionOptions = {},
+): Promise<EnsureLinkedSessionResult> {
+  const isLinked = opts.isLinked ?? isEnrichedClaims;
+  const persist = opts.persist !== false;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? defaultSleep;
+
+  const mintValuToken = async (): Promise<string> => {
+    if (opts.getValuToken) return opts.getValuToken();
+    if (opts.valuToken) return opts.valuToken;
+    throw new CuOidcConnectError(
+      'no_valu_token_source',
+      'ensureLinkedSession needs `valuToken` or `getValuToken`.',
+    );
+  };
+
+  const exchange = (token: string): Promise<ExchangeResult> =>
+    exchangeValuToken(config, token, {
+      ...(opts.audience !== undefined ? { audience: opts.audience } : {}),
+      ...(opts.scope !== undefined ? { scope: opts.scope } : {}),
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+
+  const settleLinked = (
+    result: ExchangeResult,
+    viaInterstitial: boolean,
+  ): EnsureLinkedSessionResult => {
+    if (persist) storeIdToken(config.tokenStorageKey, result.tokens.id_token);
+    return { status: 'linked', tokens: result.tokens, claims: result.claims, viaInterstitial };
+  };
+
+  // 1. First exchange — the common case is an already-linked identity.
+  const first = await exchange(await mintValuToken());
+  if (isLinked(first.claims)) {
+    return settleLinked(first, false);
+  }
+
+  // 2. Thin identity → drive the interstitial. Mint a live token for the popup
+  //    (with a `getValuToken` factory this is fresh; with a static `valuToken`
+  //    it's the same value — either way still valid for the immediate hand-off).
+  const outcome = await driveInterstitial(config, await mintValuToken(), {
+    ...(opts.interstitial ?? {}),
+  });
+  if (outcome.status === 'blocked') return { status: 'blocked' };
+
+  // CU-1050 — the bridge confirmed the co-presentation bind completed. A single
+  // re-exchange with a fresh token returns the enriched identity; no polling
+  // needed. If that one attempt somehow still reads thin (read-replica lag),
+  // fall through to the backstop poll below rather than reporting failure.
+  if (outcome.status === 'bound') {
+    const bound = await exchange(await mintValuToken());
+    if (isLinked(bound.claims)) return settleLinked(bound, true);
+    // else: fall through to the poll.
+  } else if (outcome.status !== 'sent') {
+    // 'dismissed' (user closed) or 'timed-out' (never readied / never sent).
+    return outcome.status === 'dismissed' ? { status: 'dismissed' } : { status: 'pending' };
+  }
+
+  // 3. Magic link sent (bridge couldn't confirm the click) or bound-but-still-
+  //    thin. If the caller opted out of waiting, hand back control.
+  if (opts.waitForLink === false) return { status: 'pending' };
+
+  // 4. Re-exchange on return: poll until the identity links or we time out.
+  //    Re-mint per attempt so a slow email click doesn't hit an expired token.
+  //    With a STATIC valuToken there is nothing fresh to re-mint, so once the
+  //    server rejects it (expiry) every further attempt fails identically —
+  //    break out with the error instead of spinning silently to the deadline
+  //    and returning a bare `pending` that hides a possibly-completed link.
+  const pollIntervalMs = opts.pollIntervalMs ?? 2500;
+  const pollTimeoutMs = opts.pollTimeoutMs ?? 120_000;
+  const canRemint = opts.getValuToken !== undefined;
+  const deadline = now() + pollTimeoutMs;
+  let lastError: CuOidcConnectError | undefined;
+  while (now() < deadline) {
+    await sleep(pollIntervalMs);
+    let attempt: ExchangeResult;
+    try {
+      attempt = await exchange(await mintValuToken());
+    } catch (err) {
+      lastError = err instanceof CuOidcConnectError ? err : undefined;
+      // A rejected exchange on a non-re-mintable (static) token can never
+      // recover — the same expired token would be re-sent. Stop and surface it
+      // so the caller re-invokes with a fresh token. Transient network faults
+      // (`exchange_request_failed`) and re-mintable tokens keep polling.
+      if (!canRemint && lastError?.reason === 'exchange_failed') break;
+      continue;
+    }
+    lastError = undefined; // a successful (still-thin) exchange clears the error
+    if (isLinked(attempt.claims)) {
+      return settleLinked(attempt, true);
+    }
+  }
+  return lastError ? { status: 'pending', lastError } : { status: 'pending' };
+}

--- a/src/cu-oidc/index.ts
+++ b/src/cu-oidc/index.ts
@@ -50,6 +50,33 @@ export type {
   HandleReceiverOptions,
 } from './silent-sso';
 
+// --- cross-method identity linking (CU-1049 / CU-1047) ---
+export {
+  exchangeValuToken,
+  driveInterstitial,
+  ensureLinkedSession,
+  isEnrichedClaims,
+  CuOidcConnectError,
+  TOKEN_EXCHANGE_GRANT_TYPE,
+  VALU_IDENTITY_SUBJECT_TOKEN_TYPE,
+  ID_TOKEN_ISSUED_TOKEN_TYPE,
+  CONNECT_ACCOUNT_PATH,
+  MSG_CONNECT_READY,
+  MSG_VALU_TOKEN,
+  MSG_MAGIC_LINK_SENT,
+} from './connect-account';
+export type {
+  ExchangeValuTokenOptions,
+  ExchangeResult,
+  PopupLike,
+  OpenPopupFn,
+  MessageTargetLike,
+  DriveInterstitialOptions,
+  InterstitialOutcome,
+  EnsureLinkedSessionOptions,
+  EnsureLinkedSessionResult,
+} from './connect-account';
+
 // --- JWKS verification ---
 export {
   verifyIdToken,


### PR DESCRIPTION
## Summary

The **mini-app half** of cross-method identity linking (CU-1047). When a mini-app exchanges a Valu token and gets back a **thin** (unlinked) session, this drives the cu-oidc-hosted connect-account interstitial, completes the bind under the CU-1050 co-presentation gate, and re-exchanges to the **enriched** token.

Pairs with — and co-promotes with — the cu-oidc PR (`feature/CU-1047-cross-method-identity-linking`), which ships the intake, the CU-1050 gate, and the bridge this SDK talks to.

## What changed

- **`exchangeValuToken`** — RFC 8693 token-exchange, secretless (the signed Valu token is the credential).
- **`driveInterstitial`** — opens the cu-oidc popup and hands it the Valu token via `postMessage` (issuer origin only). **CU-1050 terminal-signal redesign:**
  - `magic-link-sent` is now **intermediate** — the link was emailed, but the bind hasn't happened.
  - the new **terminal** signal is `cu-oidc:linked`, which the bridge posts only after its own **same-origin** `complete-bind` poll actually bound the identity → `{ status: 'bound' }`.
  - degrades to `{ status: 'sent' }` (backstop) if the bridge can't confirm the click within `bindTimeoutMs` (default 300s — the Valu-token TTL bound) or the popup closes after send.
- **`ensureLinkedSession`** — exchange → classify linked vs thin → drive only when thin. On `bound`, a single re-exchange returns the enriched token. The pre-existing re-exchange poll survives **only** as a backstop for the `sent` path: under CU-1050 it can **detect** a completed bind but never **cause** one.

## Why the SDK can't complete the bind itself (by design)

The `cu_bind_proof` cookie is HttpOnly and same-origin to cu-oidc. The SDK is cross-origin, so it cannot read or send that cookie. Only the cu-oidc bridge (same-origin) co-presents the cookie + token. This SDK's role is to **launch** the interstitial and **react** to `cu-oidc:linked`, never to perform the security-sensitive bind.

## Acceptance criteria

- [x] Thin/unlinked Valu session drives the interstitial; linked session does not (CU-1049)
- [x] `cu-oidc:linked` → single re-exchange → enriched token (CU-1050)
- [x] `magic-link-sent` treated as intermediate, not terminal (CU-1050)
- [x] Only the issuer origin may hand a token / signal linked; attacker origin rejected (CU-1050)
- [x] Graceful degradation to `sent` on bridge-absent / bind-timeout / popup-closed

## Test plan

- [x] `connect-account.test.ts` — 20 tests incl. bound-on-linked, magic-link-sent-is-intermediate, close-after-send → sent, bind-timeout → sent, attacker-origin-linked rejected
- [x] **Full suite: 503 passed (27 files); type-check + lint clean**

Part of CU-1049
Part of CU-1050
Advances CU-1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
