### PR TITLE
chore(release): bump auth-sdk to 1.0.0-beta.2 (CU-1050)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Bumps `@chabaduniverse/auth-sdk` from `1.0.0-beta.1` → `1.0.0-beta.2`. **Version metadata only — no code change.**

## Why

PR #32 (connect-account interstitial drive + CU-1050 completion) merged to `main` but left `package.json` at `1.0.0-beta.1` — a version **already published to npm** (dist-tag `beta`). npm versions are immutable, so:

- `main`'s `1.0.0-beta.1` no longer matches the published `1.0.0-beta.1` (content divergence).
- `npm publish` from `main` would be rejected — you can't republish an existing version.

This bump makes `main` publish-ready.

## Publish is intentionally NOT done in this PR

The connect-account flow is inert until **both** cu-oidc's config gates (`VALU_EXPECTED_AUD` + `CONNECT_ACCOUNT_ALLOWED_ORIGINS`) are set **and** a mini-app adopts the new version and calls `ensureLinkedSession`. Nothing consumes it today, and the backend isn't enabled even on staging. So the actual `npm publish --tag beta` (manual + 2FA — the repo has no CI publish workflow) is sequenced with **pilot enablement**, not this PR.

## Consumer safety

The 8 Merkos repos on `^0.1–^0.3` are unaffected — caret-0.x ranges don't match a `1.0.0-beta`, and the `latest` dist-tag stays `0.4.0`. Only an explicit `@beta` or a pinned `1.0.0-beta.2` picks this up.

Part of CU-1050
Advances CU-1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
