### PR TITLE
feat(cu-oidc): shared-device confirm-identity gate (CU-1051)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cu-oidc/__tests__/connect-account.test.ts
+++ b/src/cu-oidc/__tests__/connect-account.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getClaims } from '../claims';
 import { resolveCuOidcConfig } from '../config';
 import { bytesToBase64Url } from '../crypto-utils';
 import { readIdToken } from '../storage';
@@ -61,6 +62,22 @@ const ENRICHED = jwt({
   email_verified: true,
   chabaduniverse: { user_id: 'cu-user-1', is_shliach: true },
   valu: { user_id: 'valu-abc' },
+});
+
+/**
+ * A DECODABLE Valu identity token (getClaims reads its payload) carrying a known
+ * `sub` — the confirm-gate tests assert WHICH identity got pinned to the bind.
+ * The gate reads, and driveInterstitial hands the popup, the raw Valu token
+ * (NOT the exchanged id_token), so its `sub` is what a consumer's "is this you?"
+ * check is shown and what ultimately binds.
+ */
+const VALU_SUB = 'valu-abc';
+const VALU_TOKEN = jwt({
+  sub: VALU_SUB,
+  iss: 'https://api.roomful.net',
+  aud: 'cu-test-harness',
+  iat: nowSec,
+  exp: nowSec + 300,
 });
 
 /** A fetch mock returning a JSON body with the given status. */
@@ -452,5 +469,169 @@ describe('ensureLinkedSession', () => {
     expect(lastError?.reason).toBe('exchange_failed');
     // Broke on the first failed poll (1 first-exchange + 1 poll) — no spinning.
     expect(call).toBe(2);
+  });
+
+  // --- shared-device confirmation gate (CU-1051 — pins the bound Valu sub) ----
+
+  it('shared-device gate: thin + confirmIdentity → false → declined, popup never opens, nothing persisted', async () => {
+    const openPopup = vi.fn();
+    const confirmIdentity = vi.fn(async () => false);
+
+    const res = await ensureLinkedSession(config, {
+      valuToken: VALU_TOKEN,
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      confirmIdentity,
+      interstitial: { openPopup },
+    });
+
+    expect(res).toEqual({ status: 'declined' });
+    // The gate is pinned to the EXACT sub about to be bound (CU-1051 C1).
+    expect(confirmIdentity).toHaveBeenCalledTimes(1);
+    expect(confirmIdentity).toHaveBeenCalledWith(VALU_SUB);
+    // The gate fires BEFORE the interstitial — no popup, no bind attempted...
+    expect(openPopup).not.toHaveBeenCalled();
+    // ...and a decline leaves NO first-party session behind.
+    expect(readIdToken(config.tokenStorageKey)).toBeNull();
+  });
+
+  it('shared-device gate: thin + confirmIdentity → true (receives the bound sub) → proceeds to the bind', async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      const body = call === 1 ? { access_token: THIN } : { access_token: ENRICHED };
+      return new Response(JSON.stringify(body), { status: 200 });
+    }) as unknown as typeof fetch;
+    const confirmIdentity = vi.fn(() => true);
+
+    const res = await ensureLinkedSession(config, {
+      getValuToken: async () => VALU_TOKEN,
+      fetchImpl,
+      confirmIdentity,
+      interstitial: { openPopup: autoBindingPopup(fakePopup()) },
+      sleep: async () => {
+        throw new Error('poll must not run on the bound path');
+      },
+    });
+
+    expect(confirmIdentity).toHaveBeenCalledTimes(1);
+    expect(confirmIdentity).toHaveBeenCalledWith(VALU_SUB);
+    expect(res).toMatchObject({ status: 'linked', viaInterstitial: true });
+  });
+
+  it('shared-device gate: confirmIdentity throws → rejects fail-closed, popup never opens, nothing persisted', async () => {
+    const openPopup = vi.fn();
+    const boom = new Error('valu profile fetch failed');
+    const confirmIdentity = vi.fn(async () => {
+      throw boom;
+    });
+
+    // A gate that cannot decide must fail CLOSED — the rejection propagates and
+    // no bind is attempted, rather than falling through to staple an
+    // unconfirmed sub to the email.
+    await expect(
+      ensureLinkedSession(config, {
+        valuToken: VALU_TOKEN,
+        fetchImpl: jsonFetch({ access_token: THIN }),
+        confirmIdentity,
+        interstitial: { openPopup },
+      }),
+    ).rejects.toBe(boom);
+
+    expect(openPopup).not.toHaveBeenCalled();
+    expect(readIdToken(config.tokenStorageKey)).toBeNull();
+  });
+
+  it('CU-1051 C1: the confirmed sub IS the bound sub — one mint feeds both gate and interstitial', async () => {
+    // getValuToken yields a DIFFERENT identity once the bound token is already in
+    // hand, simulating a shared-device session flip mid-flow. Because the fix
+    // mints the bound token ONCE and reuses it, the sub shown to the human MUST
+    // equal the sub posted to the interstitial — a later re-mint cannot swap the
+    // identity out from under the confirmation (the TOCTOU the old double-mint
+    // allowed). Sequence: mint#1=first-exchange, mint#2=boundToken (gate +
+    // interstitial), mint#3+=the bound re-exchange, which we let drift to ATTACKER
+    // to prove the popup still received mint#2.
+    const ATTACKER = jwt({
+      sub: 'valu-attacker',
+      iss: 'https://api.roomful.net',
+      aud: 'cu-test-harness',
+      iat: nowSec,
+      exp: nowSec + 300,
+    });
+    const seq = [VALU_TOKEN, VALU_TOKEN, ATTACKER, ATTACKER, ATTACKER];
+    let n = 0;
+    const getValuToken = () => seq[Math.min(n++, seq.length - 1)];
+
+    const popup = fakePopup();
+    let confirmedSub: string | null = 'UNSET';
+    const confirmIdentity = vi.fn((sub: string | null) => {
+      confirmedSub = sub;
+      return true;
+    });
+
+    await ensureLinkedSession(config, {
+      getValuToken,
+      fetchImpl: jsonFetch({ access_token: THIN }), // always thin → reaches the bind, stays thin after
+      confirmIdentity,
+      interstitial: { openPopup: autoBindingPopup(popup) },
+      sleep: async () => {},
+      pollTimeoutMs: 0, // don't spin the backstop poll — we only inspect what was posted
+    });
+
+    // The Valu token actually handed to the interstitial (posted to the popup)...
+    const handoff = popup.postMessage.mock.calls.find(
+      ([msg]) => (msg as { type?: string } | undefined)?.type === MSG_VALU_TOKEN,
+    )?.[0] as { token: string } | undefined;
+    const boundSub = getClaims(handoff?.token ?? '')?.sub ?? null;
+
+    // ...decodes to the SAME sub the human confirmed — never mint#3 (ATTACKER).
+    expect(confirmedSub).toBe(VALU_SUB);
+    expect(boundSub).toBe(VALU_SUB);
+    expect(confirmedSub).toBe(boundSub);
+  });
+
+  it('shared-device gate: opaque/undecodable Valu token → confirmIdentity receives null (cannot confirm)', async () => {
+    // getClaims returns null (never throws) for a token it cannot decode, so a
+    // garbage/opaque Valu token surfaces as a null sub. The gate STILL fires and
+    // hands the consumer `null` to treat as "cannot confirm" — it must not be
+    // silently coerced into a pass.
+    const confirmIdentity = vi.fn(() => false);
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'opaque-not-a-jwt',
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      confirmIdentity,
+      interstitial: { openPopup: vi.fn() },
+    });
+    expect(res).toEqual({ status: 'declined' });
+    expect(confirmIdentity).toHaveBeenCalledWith(null);
+  });
+
+  it('shared-device gate: confirmIdentity returns undefined (forgotten return) → fail-closed to declined', async () => {
+    const openPopup = vi.fn();
+    // A consumer that forgets to `return` yields undefined → falsy → the gate
+    // declines rather than falling through to a bind. `!confirmed` fails closed.
+    const confirmIdentity = vi.fn(() => undefined as unknown as boolean);
+    const res = await ensureLinkedSession(config, {
+      valuToken: VALU_TOKEN,
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      confirmIdentity,
+      interstitial: { openPopup },
+    });
+    expect(res).toEqual({ status: 'declined' });
+    expect(openPopup).not.toHaveBeenCalled();
+  });
+
+  it('shared-device gate: already linked → confirmIdentity is NOT called (no bind, no prompt)', async () => {
+    const confirmIdentity = vi.fn(() => false);
+
+    const res = await ensureLinkedSession(config, {
+      valuToken: 'valu.jwt',
+      fetchImpl: jsonFetch({ access_token: ENRICHED }),
+      confirmIdentity,
+    });
+
+    expect(res).toMatchObject({ status: 'linked', viaInterstitial: false });
+    // A returning (already-linked) user is never prompted — the gate guards the
+    // thin/bind path only, so a `false`-returning gate can't block a linked user.
+    expect(confirmIdentity).not.toHaveBeenCalled();
   });
 });

--- a/src/cu-oidc/connect-account.ts
+++ b/src/cu-oidc/connect-account.ts
@@ -464,6 +464,55 @@ export interface EnsureLinkedSessionOptions {
   isLinked?: (claims: CuOidcClaims | null) => boolean;
   /** Persist the final enriched id_token first-party (default `true`). */
   persist?: boolean;
+  /**
+   * Shared-device confirmation gate (CU-1051 — residual-risk mitigation layered
+   * on CU-1050 co-presentation). Invoked with the classified Valu `sub` on the
+   * THIN path only — immediately before the magic-link interstitial opens, i.e.
+   * the one moment a `valu sub ↔ email` bind is about to be created. Return
+   * `false` (or a promise of it) to abort: the flow then resolves
+   * `{status:'declined'}` and no popup opens and no bind is attempted. An
+   * already-linked identity never reaches this gate (it returns before the
+   * interstitial), so returning users are never prompted.
+   *
+   * Why it exists: the Valu identity token is sub-only, so the bind joins an
+   * OPAQUE `sub` to the magic-link-VERIFIED email — and the human never sees
+   * WHICH Valu identity they are binding. On a shared machine a stale Valu
+   * session (someone else's `sub`) would bind to the email owner's verified
+   * inbox, handing that other person a durable, enriched account. The magic
+   * link proves the EMAIL; it can never prove the `sub`. Surfacing the ambient
+   * Valu profile (name + avatar) lets the human catch "that isn't me" before
+   * the link goes out.
+   *
+   * The `valuSub` argument is the `sub` of the EXACT token that will be bound
+   * (decoded from the same single mint handed to the interstitial — never a
+   * second, later read of the ambient identity). Cross-check it against the
+   * profile you fetch — e.g. assert `getApi('users').run('current')`'s
+   * `.id === valuSub` before rendering "is this you?" — so the identity the
+   * human confirms is provably the identity being bound. It is `null` only if
+   * the token could not be decoded; treat that as "cannot confirm" (show the raw
+   * prompt or decline) rather than a pass.
+   *
+   * Headless by design: this SDK holds no Valu profile client of its own, so
+   * the CONSUMER supplies the check — fetch the ambient profile (Valu `users`
+   * API: `getApi('users').run('current')` for the name, then
+   * `run('get-icon', {userId})` for the avatar) and render the "is this you?"
+   * prompt inside this callback. Omit to keep the current (un-gated) behaviour.
+   *
+   * Fail-closed contract: this callback MUST settle — there is no internal
+   * timeout, so a promise that never resolves hangs the flow (no popup, no
+   * bind). If it throws or rejects, `ensureLinkedSession` rejects and NO bind
+   * occurs (consistent with a failed token-exchange); a throw never silently
+   * proceeds to a bind. Callers that `switch` on the result status must
+   * therefore also guard the call in `try/catch`.
+   *
+   * Limits: the profile is opener-asserted, not cryptographically bound to the
+   * token, so a targeted attacker who renames themselves to match the victim
+   * defeats it — this is a human sanity-check for the accidental / opportunistic
+   * shared-session case, not a cryptographic control. The durable fix is a
+   * verified `email` claim on the Valu token (not available today); until then
+   * this is the only human check on the `sub` half of the bind.
+   */
+  confirmIdentity?: (valuSub: string | null) => boolean | Promise<boolean>;
   /** Popup/handshake seams passed through to {@link driveInterstitial}. */
   interstitial?: DriveInterstitialOptions;
   /**
@@ -497,6 +546,13 @@ export type EnsureLinkedSessionResult =
   | { status: 'pending'; lastError?: CuOidcConnectError }
   /** The user closed the interstitial without submitting. */
   | { status: 'dismissed' }
+  /**
+   * The consumer's {@link EnsureLinkedSessionOptions.confirmIdentity} gate
+   * returned false — the human did not recognise the ambient Valu identity, so
+   * the flow aborted before opening the popup and no bind was attempted.
+   * Distinct from `dismissed`, which is a popup close AFTER the flow began.
+   */
+  | { status: 'declined' }
   /** The popup was blocked by the browser. */
   | { status: 'blocked' };
 
@@ -555,10 +611,25 @@ export async function ensureLinkedSession(
     return settleLinked(first, false);
   }
 
-  // 2. Thin identity → drive the interstitial. Mint a live token for the popup
-  //    (with a `getValuToken` factory this is fresh; with a static `valuToken`
-  //    it's the same value — either way still valid for the immediate hand-off).
-  const outcome = await driveInterstitial(config, await mintValuToken(), {
+  // 1a. Thin identity → a `valu sub ↔ email` bind is imminent. Mint the token
+  //     that will actually be handed to the interstitial ONCE, and pin the
+  //     consumer's confirmation to ITS `sub` (CU-1051 C1). A single read of the
+  //     ambient identity feeds BOTH the "is this you?" check and the bind, so a
+  //     mid-prompt Valu session switch on a shared device cannot make the human
+  //     confirm one identity while a second, later mint binds another — the
+  //     token confirmed IS the token bound. A `false` means the human didn't
+  //     recognise the signed-in Valu user; abort before any bind rather than
+  //     staple someone else's `sub` to this email.
+  const boundToken = await mintValuToken();
+  if (opts.confirmIdentity) {
+    const boundSub = getClaims(boundToken)?.sub ?? null;
+    const confirmed = await opts.confirmIdentity(boundSub);
+    if (!confirmed) return { status: 'declined' };
+  }
+
+  // 2. Thin identity → drive the interstitial with the SAME token whose `sub`
+  //    the consumer just confirmed (no second, unpinned re-mint).
+  const outcome = await driveInterstitial(config, boundToken, {
     ...(opts.interstitial ?? {}),
   });
   if (outcome.status === 'blocked') return { status: 'blocked' };


### PR DESCRIPTION
## Summary
Adds an optional **shared-device confirmation gate** to `ensureLinkedSession`, closing the residual account-takeover risk left by CU-1050 co-presentation. On the thin→bind path, a consumer-supplied `confirmIdentity(valuSub)` callback is asked "is this you?" *before* the magic-link interstitial opens — so on a shared machine a stale Valu session can't silently staple the wrong `sub` to the email owner's verified inbox.

The gate is **pinned to the exact token that binds** (finding C1): the Valu token is minted **once** (`boundToken`), its `sub` is read and passed to `confirmIdentity`, and the *same* token is handed to `driveInterstitial`. A single read of the ambient identity feeds both the confirmation and the bind — eliminating the check/use (TOCTOU = Time-Of-Check to Time-Of-Use) gap where a mid-prompt session flip could confirm one identity while a second re-mint bound another.

## Behavior
- `confirmIdentity` returns **false** → `{status:'declined'}`; no popup, no bind, nothing persisted.
- Gate fires **only** on the thin→bind path; an already-linked (returning) user is never prompted.
- **Fail-closed:** a throwing/rejecting gate rejects `ensureLinkedSession` with no bind; a falsy/`undefined` return declines; an undecodable Valu token surfaces a `null` sub for the consumer to reject.
- Omitting `confirmIdentity` preserves the prior (un-gated) behavior — additive and opt-in.

## Test plan
- [x] 7 confirm-gate cases in `connect-account.test.ts`: the **C1 pin** (confirmed sub == the sub posted to the interstitial, proven against a *simulated session flip*), fail-closed on throw, nothing-persisted on decline, null-sub delegation, `undefined`→declined, and already-linked skips the gate.
- [x] Full suite **510 passing**; `type-check` + `lint` + `build` all clean.
- [ ] Staging smoke via `cu-auth-harness` wired to `@chabaduniverse/auth-sdk@1.0.0-beta.3` (follow-up, same session).

## Review
Independent code-review + security-review sub-agents on the live diff: **0 block-merge / 0 critical** (verdicts: SHIP-WITH-NITS / SAFE-TO-SHIP). Both independently flagged the **same** residual — the post-bind re-exchange reads the *ambient* Valu identity rather than reusing `boundToken` — which is **pre-existing** (unchanged by this PR), low-severity (inverted threat direction: a session flip lands the victim in the attacker's *own* session, not vice-versa), and deferred to a follow-up hardening ticket.

## Release
Bumps `@chabaduniverse/auth-sdk` → **`1.0.0-beta.3`**, published under the `beta` dist-tag (`latest` / 0.4.0 stable line untouched).

Jira: **CU-1051** (sub-task of CU-1047; relates to CU-1050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
