### PR TITLE
feat(cu-oidc): forward optional email pre-fill hint through connect-account (CU-1053)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ package-lock.json
 .claude/active-ticket.md
 .claude/relay-log.md
 .claude/worktrees/
+
+# oh-my-claudecode local tooling state
+.omc/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cu-oidc/__tests__/connect-account.test.ts
+++ b/src/cu-oidc/__tests__/connect-account.test.ts
@@ -313,6 +313,50 @@ describe('driveInterstitial', () => {
     vi.advanceTimersByTime(5001);
     await expect(p).resolves.toEqual({ status: 'timed-out' });
   });
+
+  it('CU-1053: forwards a valid email hint (trimmed) in the token message', async () => {
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      emailHint: '  User@Example.com  ',
+    });
+    post(MSG_CONNECT_READY);
+    post(MSG_LINKED);
+    await p;
+    // Trimmed, case preserved, included alongside the token, issuer-targeted.
+    expect(popup.postMessage).toHaveBeenCalledWith(
+      { type: MSG_VALU_TOKEN, token: 'valu.jwt', email: 'User@Example.com' },
+      ISSUER_ORIGIN,
+    );
+  });
+
+  it('CU-1053: omits the email key entirely when no hint is supplied', async () => {
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', { openPopup: () => popup });
+    post(MSG_CONNECT_READY);
+    post(MSG_LINKED);
+    await p;
+    const msg = popup.postMessage.mock.calls.find(
+      ([m]) => (m as { type?: string })?.type === MSG_VALU_TOKEN,
+    )?.[0] as Record<string, unknown>;
+    expect(msg).toEqual({ type: MSG_VALU_TOKEN, token: 'valu.jwt' });
+    expect(msg).not.toHaveProperty('email');
+  });
+
+  it('CU-1053: drops a malformed email hint rather than posting it', async () => {
+    const popup = fakePopup();
+    const p = driveInterstitial(config, 'valu.jwt', {
+      openPopup: () => popup,
+      emailHint: 'not-an-email',
+    });
+    post(MSG_CONNECT_READY);
+    post(MSG_LINKED);
+    await p;
+    const msg = popup.postMessage.mock.calls.find(
+      ([m]) => (m as { type?: string })?.type === MSG_VALU_TOKEN,
+    )?.[0] as Record<string, unknown>;
+    expect(msg).not.toHaveProperty('email');
+  });
 });
 
 // ===========================================================================
@@ -587,6 +631,22 @@ describe('ensureLinkedSession', () => {
     expect(confirmedSub).toBe(VALU_SUB);
     expect(boundSub).toBe(VALU_SUB);
     expect(confirmedSub).toBe(boundSub);
+  });
+
+  it('CU-1053: forwards a top-level emailHint to the interstitial popup', async () => {
+    const popup = fakePopup();
+    await ensureLinkedSession(config, {
+      valuToken: VALU_TOKEN,
+      fetchImpl: jsonFetch({ access_token: THIN }),
+      emailHint: 'prefill@example.com',
+      interstitial: { openPopup: autoBindingPopup(popup) },
+      sleep: async () => {},
+      pollTimeoutMs: 0, // inspect only what was posted; don't spin the backstop poll
+    });
+    const handoff = popup.postMessage.mock.calls.find(
+      ([msg]) => (msg as { type?: string })?.type === MSG_VALU_TOKEN,
+    )?.[0] as { email?: string } | undefined;
+    expect(handoff?.email).toBe('prefill@example.com');
   });
 
   it('shared-device gate: opaque/undecodable Valu token → confirmIdentity receives null (cannot confirm)', async () => {

--- a/src/cu-oidc/connect-account.ts
+++ b/src/cu-oidc/connect-account.ts
@@ -254,6 +254,14 @@ export interface DriveInterstitialOptions {
   closePollMs?: number;
   /** Close the popup ourselves once the outcome is decided. Default `true`. */
   autoClose?: boolean;
+  /**
+   * CU-1053 — optional email pre-fill hint forwarded to the popup in the
+   * `cu-oidc:valu-token` message. The bridge pre-fills the email field with it;
+   * the user still submits explicitly (no auto-submit) and the emailed link
+   * still proves the inbox. A malformed hint is dropped. Omit when the opener
+   * has no email to offer (e.g. the sub-only test harness).
+   */
+  emailHint?: string;
 }
 
 /** Terminal outcome of the interstitial popup handshake. */
@@ -294,6 +302,21 @@ const defaultOpenPopup: OpenPopupFn = (url, name, features) => {
 };
 
 /**
+ * CU-1053 — validate an optional email pre-fill hint before it is posted to the
+ * connect-account popup. A convenience only (the emailed link still proves the
+ * inbox), so a malformed hint is silently dropped rather than raised. Mirrors
+ * the bridge's structural check + 254-char ceiling; case is preserved (the
+ * server canonicalises).
+ */
+const EMAIL_HINT_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+function normalizeEmailHint(hint: string | undefined): string | undefined {
+  if (typeof hint !== 'string') return undefined;
+  const trimmed = hint.trim();
+  if (trimmed.length === 0 || trimmed.length > 254) return undefined;
+  return EMAIL_HINT_RE.test(trimmed) ? trimmed : undefined;
+}
+
+/**
  * Open cu-oidc's `/oidc/connect-account` popup and run the postMessage
  * handshake with `connect-account-bridge.js`:
  *
@@ -332,6 +355,7 @@ export function driveInterstitial(
   const bindTimeoutMs = opts.bindTimeoutMs ?? 300_000;
   const closePollMs = opts.closePollMs ?? 500;
   const autoClose = opts.autoClose !== false;
+  const emailHint = normalizeEmailHint(opts.emailHint);
 
   return new Promise<InterstitialOutcome>((resolve) => {
     const popup = openPopup(pageUrl, 'cu_oidc_connect_account', DEFAULT_POPUP_FEATURES);
@@ -392,7 +416,14 @@ export function driveInterstitial(
         // Arm the "user is typing their email" window now that the page is up.
         sentTimer = setTimeout(() => finish({ status: 'timed-out' }), sentTimeoutMs);
         try {
-          popup.postMessage({ type: MSG_VALU_TOKEN, token: valuToken }, issuerOrigin);
+          // CU-1053 — include the validated email hint only when present, so the
+          // no-hint message shape stays exactly `{ type, token }`.
+          popup.postMessage(
+            emailHint
+              ? { type: MSG_VALU_TOKEN, token: valuToken, email: emailHint }
+              : { type: MSG_VALU_TOKEN, token: valuToken },
+            issuerOrigin,
+          );
         } catch {
           finish({ status: 'timed-out' });
         }
@@ -516,6 +547,14 @@ export interface EnsureLinkedSessionOptions {
   /** Popup/handshake seams passed through to {@link driveInterstitial}. */
   interstitial?: DriveInterstitialOptions;
   /**
+   * CU-1053 — optional email pre-fill hint. Forwarded to the connect-account
+   * popup (via {@link driveInterstitial}) so the field arrives pre-filled when
+   * the consuming app already knows the user's address. Convenience only: the
+   * user still submits explicitly and the emailed link proves the inbox. An
+   * `emailHint` set directly on {@link interstitial} takes precedence.
+   */
+  emailHint?: string;
+  /**
    * After the magic link is sent, poll a re-exchange until the identity links
    * (the user clicked the link) or {@link pollTimeoutMs} elapses. Default
    * `true`. Set `false` to return `{status:'pending'}` immediately after send
@@ -629,8 +668,14 @@ export async function ensureLinkedSession(
 
   // 2. Thin identity → drive the interstitial with the SAME token whose `sub`
   //    the consumer just confirmed (no second, unpinned re-mint).
+  const interstitialOpts = opts.interstitial ?? {};
   const outcome = await driveInterstitial(config, boundToken, {
-    ...(opts.interstitial ?? {}),
+    ...interstitialOpts,
+    // CU-1053 — forward the top-level email hint unless the caller set one
+    // directly on the interstitial seams (the explicit lower-level one wins).
+    ...(interstitialOpts.emailHint === undefined && opts.emailHint !== undefined
+      ? { emailHint: opts.emailHint }
+      : {}),
   });
   if (outcome.status === 'blocked') return { status: 'blocked' };
 


### PR DESCRIPTION
## Summary
- `driveInterstitial` / `ensureLinkedSession` accept an optional **`emailHint`**,
  forwarded to the connect-account popup in the `cu-oidc:valu-token` message so a
  consuming app that already knows the user's address can pre-fill the email field.
- Convenience only: the user still submits explicitly, and the emailed magic link
  still proves inbox control. A hint set directly on the interstitial seams wins
  over the top-level one.
- `normalizeEmailHint()` trims, enforces a 254-char ceiling, applies a structural
  check, and **silently drops** a malformed hint (case preserved; server
  canonicalises). The no-hint message stays byte-for-byte `{ type, token }`.

## Acceptance criteria
- [x] `emailHint` accepted on both `driveInterstitial` and `ensureLinkedSession`
- [x] Forwarded as `email` in the `cu-oidc:valu-token` message only when valid
- [x] Malformed / empty / oversized hints dropped, not posted
- [x] No-hint message shape unchanged (sub-only openers unaffected)
- [x] Interstitial-level hint takes precedence over the top-level one

## Test plan
- [x] 4 new tests (valid trimmed hint forwarded, no-hint omits key, malformed
      dropped, top-level hint threaded through `ensureLinkedSession`)
- [x] Full gate: type-check + 514 tests + build + lint all clean

## Notes
- Bumps `1.0.0-beta.3 -> 1.0.0-beta.4`. Publishing beta.4 to the `beta` tag also
  ships the as-yet-unpublished **beta.3 (CU-1051 shared-device confirm)** — beta.4's
  tree is a superset of `main`. `latest` stays `0.4.0`.
- Provider side (connect-account bridge that reads `email`) already merged
  (cu-oidc-provider PR #119).

Closes CU-1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RB9jFPm1aSMhe5WZcKt6kH