### PR TITLE
beta.5: surface merkos_token (#4) + useCuOidc resync/ensureLinkedSession (CU-1058)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chabaduniverse/auth-sdk",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Unified authentication SDK for Chabad Universe ecosystem",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cu-oidc/__tests__/connect-account.test.ts
+++ b/src/cu-oidc/__tests__/connect-account.test.ts
@@ -149,6 +149,20 @@ describe('exchangeValuToken', () => {
     expect(new URLSearchParams(capturedBody).get('audience')).toBe('miniapp');
   });
 
+  it('surfaces merkos_token when the exchange response carries it (issue_legacy_token client)', async () => {
+    const { tokens } = await exchangeValuToken(config, 'valu.jwt', {
+      fetchImpl: jsonFetch({ access_token: ENRICHED, merkos_token: 'HS256.merkos.jwt' }),
+    });
+    expect(tokens.merkos_token).toBe('HS256.merkos.jwt');
+  });
+
+  it('leaves merkos_token undefined when the response omits it', async () => {
+    const { tokens } = await exchangeValuToken(config, 'valu.jwt', {
+      fetchImpl: jsonFetch({ access_token: ENRICHED }),
+    });
+    expect(tokens.merkos_token).toBeUndefined();
+  });
+
   it('throws CuOidcConnectError on a non-2xx / empty response', async () => {
     await expect(
       exchangeValuToken(config, 'valu.jwt', { fetchImpl: jsonFetch({ error: 'invalid_grant' }, 400) }),

--- a/src/cu-oidc/__tests__/login.test.ts
+++ b/src/cu-oidc/__tests__/login.test.ts
@@ -96,6 +96,21 @@ describe('handleLoginCallback', () => {
     expect((init as RequestInit).headers).not.toHaveProperty('Authorization');
   });
 
+  it('passes merkos_token through when the client has issue_legacy_token', async () => {
+    const state = 'S-LEGACY';
+    const nonce = 'N-LEGACY';
+    stashFor(state, nonce);
+    const idToken = await signTestJwt(key, sampleClaims({ nonce }));
+    const fetchImpl = tokenResponse({ id_token: idToken, merkos_token: 'HS256.authcode.jwt' });
+
+    const result = await handleLoginCallback(config, {
+      url: `${config.redirectUri}?code=AUTH_CODE&state=${state}`,
+      fetchImpl,
+      jwks: key.jwks,
+    });
+    expect(result.tokens.merkos_token).toBe('HS256.authcode.jwt');
+  });
+
   it('rejects an unknown/expired state (no stash → CSRF guard)', async () => {
     await expect(
       handleLoginCallback(config, {
@@ -161,6 +176,13 @@ describe('refreshTokens', () => {
 
     const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(String((init as RequestInit).body)).toContain('grant_type=refresh_token');
+  });
+
+  it('passes a freshly-minted merkos_token through on refresh', async () => {
+    const idToken = await signTestJwt(key, sampleClaims());
+    const fetchImpl = tokenResponse({ id_token: idToken, merkos_token: 'HS256.rolled.jwt' });
+    const tokens = await refreshTokens(config, 'OLD_RT', { fetchImpl });
+    expect(tokens.merkos_token).toBe('HS256.rolled.jwt');
   });
 
   it('throws when no refresh_token is supplied', async () => {

--- a/src/cu-oidc/__tests__/useCuOidc.test.tsx
+++ b/src/cu-oidc/__tests__/useCuOidc.test.tsx
@@ -74,4 +74,53 @@ describe('useCuOidc', () => {
     expect(result.current.token).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
   });
+
+  it('resync() re-reads a token written outside the hook into reactive state (CU-1058)', async () => {
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    expect(result.current.token).toBeNull();
+
+    // A non-hook code path writes the token directly to storage.
+    const token = await signTestJwt(key, sampleClaims());
+    localStorage.setItem('cu_id_token', token);
+    // Not reflected yet — the hook didn't make the write and there's no storage listener.
+    expect(result.current.token).toBeNull();
+
+    act(() => {
+      result.current.resync();
+    });
+    expect(result.current.token).toBe(token);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('ensureLinkedSession() re-syncs hook state on success without a remount (CU-1058)', async () => {
+    const token = await signTestJwt(key, sampleClaims());
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    expect(result.current.token).toBeNull();
+
+    // Stand in for a successful link that persists the id_token, the way the real
+    // client.ensureLinkedSession does — the hook must reflect it with no remount.
+    vi.spyOn(result.current.client, 'ensureLinkedSession').mockImplementation(async () => {
+      localStorage.setItem('cu_id_token', token);
+      return { status: 'linked', tokens: { id_token: token }, claims: null, viaInterstitial: false };
+    });
+
+    await act(async () => {
+      await result.current.ensureLinkedSession();
+    });
+    expect(result.current.token).toBe(token);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('ensureLinkedSession() surfaces the error and clears loading on failure (CU-1058)', async () => {
+    const { result } = renderHook(() => useCuOidc(CONFIG));
+    vi.spyOn(result.current.client, 'ensureLinkedSession').mockRejectedValue(new Error('exchange boom'));
+
+    await act(async () => {
+      await expect(result.current.ensureLinkedSession()).rejects.toThrow('exchange boom');
+    });
+
+    expect(result.current.error).toBe('exchange boom');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.token).toBeNull();
+  });
 });

--- a/src/cu-oidc/connect-account.ts
+++ b/src/cu-oidc/connect-account.ts
@@ -1,13 +1,21 @@
 /**
  * cu-oidc — cross-method identity linking, consumer side (CU-1049 / CU-1047).
  *
- * The problem: a mini-app inside the Valu shell holds a Valuverse identity
- * token. Exchanging it at cu-oidc (RFC 8693) mints a cu-oidc token, but if
- * this Valu identity has never been linked to a magic-link-verified email the
- * `cu_users` row is "thin" — keyed by `valu_user_id`, no email, no SF/Neo4j
- * enrichment. The user's enriched identity (a magic-link-first row keyed by
- * email) exists separately and nothing joins them, because the Valu token
- * carries no email.
+ * The problem (as of 2026-07-21, narrower than it used to be): a mini-app
+ * inside the Valu shell holds a Valuverse identity token. Exchanging it at
+ * cu-oidc (RFC 8693) mints a cu-oidc token, but if this Valu identity has
+ * never been linked to a magic-link-verified email the `cu_users` row is
+ * "thin" — keyed by `valu_user_id`, no email, no SF/Neo4j enrichment. Until
+ * 2026-07-21 this was universal (the Valu token carried no email at all); Valu
+ * now includes a verified email in the identity token for any user who has
+ * completed a Merkos-mediated login into Valuverse at least once (live-
+ * verified via a signature-checked capture — see the trust-gate comment on
+ * cu-oidc's `token-exchange-grant.ts`). So `exchangeValuToken`'s first call
+ * now typically comes back already-enriched for such users, with no
+ * interstitial needed. This module's flow still matters for the identities
+ * Valu hasn't attached an email to yet — the genuinely thin case, not
+ * "every Valu identity" — and for the `email_verified`-precision case still
+ * pending on Valu's side (see `isEnrichedClaims` below).
  *
  * The fix (CU-1048 backend + this module): a self-verifying magic-link
  * interstitial. cu-oidc hosts a page that receives the Valu token via

--- a/src/cu-oidc/connect-account.ts
+++ b/src/cu-oidc/connect-account.ts
@@ -175,6 +175,7 @@ export async function exchangeValuToken(
     expires_in?: number;
     scope?: string;
     issued_token_type?: string;
+    merkos_token?: string;
   };
 
   // RFC 8693 §2.2: the issued id_token rides in `access_token`.
@@ -190,6 +191,9 @@ export async function exchangeValuToken(
     ...(payload.token_type ? { token_type: payload.token_type } : {}),
     ...(payload.expires_in !== undefined ? { expires_in: payload.expires_in } : {}),
     ...(payload.scope ? { scope: payload.scope } : {}),
+    // Raw HS256 Merkos-Platform token; a top-level field on the token-exchange
+    // response, present only when the client has `issue_legacy_token: true`.
+    ...(payload.merkos_token ? { merkos_token: payload.merkos_token } : {}),
   };
 
   return { tokens, claims: getClaims(issued) };

--- a/src/cu-oidc/types.ts
+++ b/src/cu-oidc/types.ts
@@ -149,6 +149,16 @@ export interface CuOidcTokens {
   token_type?: string;
   expires_in?: number;
   scope?: string;
+  /**
+   * Raw HS256 Merkos-Platform token — the top-level `merkos_token` field on the
+   * `/oidc/token` response. Present ONLY when the requesting client is
+   * registered with `issue_legacy_token: true`; absent otherwise. Undecoded on
+   * purpose — decode/verify it yourself before trusting it. Rides the
+   * authorization_code, refresh_token, AND token-exchange grants (each refresh
+   * mints a fresh ~14-day token). For Merkos-Platform-API calls; NOT for
+   * app-session gating (use the RS256 `id_token` for that).
+   */
+  merkos_token?: string;
 }
 
 /** Result of a completed authorization-code exchange (login callback). */

--- a/src/cu-oidc/useCuOidc.ts
+++ b/src/cu-oidc/useCuOidc.ts
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createCuOidcClient, type ClientVerifyOptions, type CuOidcClient, type LogoutOptions } from './client';
 import type { StartLoginOptions, HandleLoginCallbackOptions, RefreshTokensOptions } from './login';
 import type { StartSilentSsoOptions, HandleReceiverOptions } from './silent-sso';
+import type { EnsureLinkedSessionOptions, EnsureLinkedSessionResult } from './connect-account';
 import type {
   CuOidcClaims,
   CuOidcConfig,
@@ -44,8 +45,28 @@ export interface UseCuOidcReturn {
   silentSSO: (opts?: StartSilentSsoOptions) => string;
   /** Handle the silent-SSO return hop; updates state on `authenticated`. */
   handleReceiver: (opts?: HandleReceiverOptions) => Promise<CuOidcSilentResult>;
-  /** Refresh the token set; updates state on success. */
+  /**
+   * Ensure the identity behind the ambient Valu token is linked (exchange +
+   * self-verifying magic-link interstitial as needed), then re-read the STORED
+   * session into hook state on success. Prefer this over
+   * `client.ensureLinkedSession()` directly — a direct client write would not
+   * re-sync the mounted hook (CU-1058). Note: hook state mirrors storage, so
+   * this has no effect on `token`/`isAuthenticated` when called with
+   * `persist: false` — read the returned `result.tokens` in that case.
+   */
+  ensureLinkedSession: (opts?: EnsureLinkedSessionOptions) => Promise<EnsureLinkedSessionResult>;
+  /**
+   * Exchange a `refresh_token` for a NEW token set (network call); updates
+   * state on success. Contrast `resync()`, which only re-reads local storage.
+   */
   refresh: (refreshToken: string, opts?: RefreshTokensOptions) => Promise<CuOidcTokens>;
+  /**
+   * Re-read the stored session into hook state. Use after a write the hook
+   * did not make itself (e.g. a direct `client.ensureLinkedSession()` call, or
+   * a token written by another code path). Local-only — no network. Contrast
+   * `refresh()`, which exchanges a refresh_token for a new token set.
+   */
+  resync: () => void;
   /** Verify a token (JWKS signature + iss + exp). */
   verify: (token: string, opts?: ClientVerifyOptions) => Promise<CuOidcClaims>;
   /** Clear the stored token and navigate to `/oidc/session/end`. */
@@ -166,6 +187,29 @@ export function useCuOidc(config: CuOidcConfig): UseCuOidcReturn {
     [client, sync],
   );
 
+  const ensureLinkedSession = useCallback(
+    async (opts?: EnsureLinkedSessionOptions) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await client.ensureLinkedSession(opts);
+        if (mounted.current) sync();
+        return result;
+      } catch (e) {
+        if (mounted.current) setError(e instanceof Error ? e.message : String(e));
+        throw e;
+      } finally {
+        if (mounted.current) setIsLoading(false);
+      }
+    },
+    [client, sync],
+  );
+
+  // CU-1058: manual, local-only re-read of the stored session into hook state.
+  const resync = useCallback(() => {
+    if (mounted.current) sync();
+  }, [sync]);
+
   return {
     client,
     token,
@@ -178,7 +222,9 @@ export function useCuOidc(config: CuOidcConfig): UseCuOidcReturn {
     handleLoginCallback,
     silentSSO,
     handleReceiver,
+    ensureLinkedSession,
     refresh,
+    resync,
     verify,
     logout,
   };


### PR DESCRIPTION
## Summary
beta.5 keystone for the cross-repo identity/token plan — two small, additive,
backward-compatible changes to the cu-oidc surface.

- **#4 — surface `merkos_token`.** cu-oidc's `/oidc/token` returns a top-level
  `merkos_token` (raw HS256 Merkos-Platform token) when the client has
  `issue_legacy_token`; the SDK previously dropped it. Now exposed as
  `tokens.merkos_token` on `exchangeValuToken()` (token-exchange),
  `handleLoginCallback()` (auth-code), and `refresh()` — raw/undecoded, absent
  when not issued. Lets a cu-oidc-native app read the second token via a clean
  accessor instead of hand-rolling a `/oidc/token` fetch.
- **CU-1058 — `useCuOidc` staleness fix.** The hook now wraps
  `ensureLinkedSession` (re-syncs on success) + exposes it, and adds a
  local-only `resync()`. Fixes a direct `client.ensureLinkedSession()` write
  not reflecting in the mounted hook until remount.

## Commits
- `docs(cu-oidc)` — pre-existing header doc refinement (thin-user narrative)
- `feat(cu-oidc)` — surface merkos_token
- `fix(cu-oidc)` — useCuOidc resync + ensureLinkedSession (CU-1058)
- `chore(release)` — bump to 1.0.0-beta.5

## Verification
- type-check ✅ · lint ✅ · build ✅
- Full suite: **521 passing** (7 new: merkos_token present/absent on exchange,
  pass-through on auth-code + refresh, resync, ensureLinkedSession
  sync-on-success + error path)
- Independent code review: **APPROVE** — both load-bearing claims verified
  (pass-through on all 3 grants; no leakage of the HS256 token into
  storage/state/logs); 2 LOW review fixes applied.

## Compatibility
Purely additive — no breaking changes for beta.4 consumers. The credential-gate
path (`exchange → tokens.id_token → JWKS-verify → read chabaduniverse claims`)
is unchanged.

## Release
`npm publish` (manual, from `main`) after merge. The broker
(`useMerkosPlatformToken`, #1) is **not** in this release — separate follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RazsFL1XD7PJfyW7N8qVTQ
