### PR TITLE
chore(build): approve esbuild build scripts for pnpm (fix ERR_PNPM_IGNORED_BUILDS)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm blocks dependency build/install scripts by default (supply-chain safety,
+# v10+). esbuild's postinstall links its prebuilt native binary; approving it
+# here stops pnpm erroring on the ignored build during its dep-status check,
+# which otherwise breaks `pnpm build` / `pnpm test`.
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## What
Adds `pnpm-workspace.yaml` approving esbuild's install/build script:

```yaml
allowBuilds:
  esbuild: true
```

## Why
pnpm 10+ blocks dependency build/install scripts by default (supply-chain
safety). esbuild ships its native binary in a prebuilt platform package and its
postinstall just links it — harmless — but pnpm 11.x treats the *unapproved*
build as a hard error (`ERR_PNPM_IGNORED_BUILDS`) during its dep-status check.
On a fresh `node_modules` that makes the wrapped `pnpm build` / `pnpm test`
fail — which is exactly what tripped the beta.5 publish's `prepublishOnly` hook.
Approving esbuild clears the gate for everyone on a clean install.

## Verification
- `pnpm install` now runs esbuild's postinstall to completion — no
  `ERR_PNPM_IGNORED_BUILDS`.
- `pnpm build` ✅ and `pnpm test` ✅ (521 passing) via the wrapped scripts.

## Notes
- `allowBuilds` (pkg → bool map) is pnpm 11.x's field — the older
  `onlyBuiltDependencies` array is not honored by this pnpm version (verified).
- No code change; config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RazsFL1XD7PJfyW7N8qVTQ
